### PR TITLE
Load GigaChat settings from gradle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,26 @@
 ### Получите OAuth-креденшлы
 
 1. Зарегистрируйте приложение в личном кабинете GigaChat и запросите доступ к **Client Credentials**.
-2. Сохраните значение `client_id`, `client_secret`, URL для получения токенов и базовый URL API.
+2. Сохраните базовый URL API, URL для получения токенов, `api_key` и параметры для mTLS (сертификат, приватный ключ, корневой сертификат).
 3. При необходимости уточните scope и модель (если хотите отличные от стандартных `GIGACHAT_API_PERS` и `GigaChat`).
 
 ### Установите переменные окружения
 
-Агент считывает настройки из переменных окружения или системных свойств JVM. Минимальный набор:
+Агент считывает настройки из переменных окружения, системных свойств JVM или файла `gradle.properties`. Минимальный набор:
 
 ```bash
-export GIGACHAT_BASE_URL="https://gigachat.sberdevices.ru/api/v1"
-export GIGACHAT_AUTH_URL="https://auth.sberdevices.ru/as/token.oauth2"
-export GIGACHAT_CLIENT_ID="<ваш_client_id>"
-export GIGACHAT_CLIENT_SECRET="<ваш_client_secret>"
-# Необязательно, но можно переопределить
+export GIGACHAT_API_BASE="https://gigachat.devices.sberbank.ru/"
+export GIGACHAT_AUTH_URL="https://ngw.devices.sberbank.ru:9443/api/v2/oauth"
+export GIGACHAT_API_KEY="<ваш_api_key>"
+# Необязательно, но можно переопределить и дополнить
 export GIGACHAT_SCOPE="GIGACHAT_API_PERS"
-export GIGACHAT_MODEL="GigaChat"
+export GIGACHAT_MODEL="GigaChat-2-Max"
+export GIGACHAT_CERT_FILE="/path/to/cert.pem"
+export GIGACHAT_KEY_FILE="/path/to/key.key"
+export GIGACHAT_CA_FILE="/path/to/ca.pem"
 ```
 
-Переменные можно задать и через `-D`-параметры JVM (например, `-DGIGACHAT_BASE_URL=...`). При запуске токен автоматически кэшируется и переиспользуется до истечения срока действия.
+Переменные можно задать и через `-D`-параметры JVM (например, `-DGIGACHAT_API_BASE=...`) или поместить в `gradle.properties` проекта. При запуске токен автоматически кэшируется и переиспользуется до истечения срока действия.
 
 ## 2. Запуск генератора
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
+GIGACHAT_API_BASE=https://gigachat.devices.sberbank.ru/
+GIGACHAT_API_KEY=
+GIGACHAT_MODEL=GigaChat-2-Max
+GIGACHAT_CERT_FILE=
+GIGACHAT_KEY_FILE=
+GIGACHAT_CA_FILE=
+GIGACHAT_AUTH_URL=https://ngw.devices.sberbank.ru:9443/api/v2/oauth

--- a/src/main/java/com/example/agent/providers/GigachatTokenProvider.java
+++ b/src/main/java/com/example/agent/providers/GigachatTokenProvider.java
@@ -48,15 +48,19 @@ public class GigachatTokenProvider {
     }
 
     private GigachatToken fetchToken() {
-        String payload = "scope=" + encode(config.getScope()) +
-                "&client_id=" + encode(config.getClientId()) +
-                "&client_secret=" + encode(config.getClientSecret()) +
-                "&grant_type=client_credentials";
+        StringBuilder payload = new StringBuilder();
+        payload.append("scope=").append(encode(config.getScope()))
+                .append("&client_id=").append(encode(config.getClientId()))
+                .append("&grant_type=client_credentials");
+        String secret = config.getClientSecret();
+        if (secret != null && !secret.isBlank()) {
+            payload.append("&client_secret=").append(encode(secret));
+        }
 
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(config.getAuthUrl())
                 .header("Content-Type", "application/x-www-form-urlencoded")
-                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                .POST(HttpRequest.BodyPublishers.ofString(payload.toString(), StandardCharsets.UTF_8))
                 .build();
 
         try {

--- a/src/main/java/com/example/tests/generator/config/GigachatClientConfig.java
+++ b/src/main/java/com/example/tests/generator/config/GigachatClientConfig.java
@@ -17,18 +17,24 @@ public class GigachatClientConfig {
     private final String model;
     private final RetryPolicy retryPolicy;
     private final Duration connectTimeout;
+    private final String certificateFile;
+    private final String keyFile;
+    private final String caFile;
 
     private GigachatClientConfig(Builder builder) {
         this.baseUrl = Objects.requireNonNull(builder.baseUrl, "baseUrl");
         this.authUrl = Objects.requireNonNull(builder.authUrl, "authUrl");
         this.clientId = Objects.requireNonNull(builder.clientId, "clientId");
-        this.clientSecret = Objects.requireNonNull(builder.clientSecret, "clientSecret");
+        this.clientSecret = builder.clientSecret;
         this.scope = builder.scope == null ? "GIGACHAT_API_PERS" : builder.scope;
         this.model = builder.model == null ? "GigaChat" : builder.model;
         this.retryPolicy = builder.retryPolicy == null
                 ? new RetryPolicy(3, Duration.ofSeconds(1), Duration.ofSeconds(30), 2.0)
                 : builder.retryPolicy;
         this.connectTimeout = builder.connectTimeout == null ? Duration.ofSeconds(10) : builder.connectTimeout;
+        this.certificateFile = builder.certificateFile;
+        this.keyFile = builder.keyFile;
+        this.caFile = builder.caFile;
     }
 
     public URI getBaseUrl() {
@@ -55,6 +61,18 @@ public class GigachatClientConfig {
         return model;
     }
 
+    public String getCertificateFile() {
+        return certificateFile;
+    }
+
+    public String getKeyFile() {
+        return keyFile;
+    }
+
+    public String getCaFile() {
+        return caFile;
+    }
+
     public RetryPolicy getRetryPolicy() {
         return retryPolicy;
     }
@@ -76,6 +94,9 @@ public class GigachatClientConfig {
         private String model;
         private RetryPolicy retryPolicy;
         private Duration connectTimeout;
+        private String certificateFile;
+        private String keyFile;
+        private String caFile;
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = URI.create(baseUrl);
@@ -114,6 +135,21 @@ public class GigachatClientConfig {
 
         public Builder model(String model) {
             this.model = model;
+            return this;
+        }
+
+        public Builder certificateFile(String certificateFile) {
+            this.certificateFile = certificateFile;
+            return this;
+        }
+
+        public Builder keyFile(String keyFile) {
+            this.keyFile = keyFile;
+            return this;
+        }
+
+        public Builder caFile(String caFile) {
+            this.caFile = caFile;
             return this;
         }
 

--- a/src/main/java/com/example/tests/generator/config/GigachatClientProperties.java
+++ b/src/main/java/com/example/tests/generator/config/GigachatClientProperties.java
@@ -1,46 +1,107 @@
 package com.example.tests.generator.config;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * Utility that reads Gigachat credentials from environment variables or system properties.
  */
 public final class GigachatClientProperties {
 
-    private static final String BASE_URL = "GIGACHAT_BASE_URL";
+    private static final String API_BASE = "GIGACHAT_API_BASE";
+    private static final String LEGACY_BASE_URL = "GIGACHAT_BASE_URL";
     private static final String AUTH_URL = "GIGACHAT_AUTH_URL";
-    private static final String CLIENT_ID = "GIGACHAT_CLIENT_ID";
+    private static final String API_KEY = "GIGACHAT_API_KEY";
+    private static final String LEGACY_CLIENT_ID = "GIGACHAT_CLIENT_ID";
     private static final String CLIENT_SECRET = "GIGACHAT_CLIENT_SECRET";
     private static final String SCOPE = "GIGACHAT_SCOPE";
     private static final String MODEL = "GIGACHAT_MODEL";
+    private static final String CERT_FILE = "GIGACHAT_CERT_FILE";
+    private static final String KEY_FILE = "GIGACHAT_KEY_FILE";
+    private static final String CA_FILE = "GIGACHAT_CA_FILE";
+
+    private static final Properties GRADLE_PROPERTIES = loadGradleProperties();
 
     private GigachatClientProperties() {
     }
 
     public static GigachatClientConfig load() {
         GigachatClientConfig.Builder builder = GigachatClientConfig.builder()
-                .baseUrl(getRequired(BASE_URL))
+                .baseUrl(getRequired(API_BASE, LEGACY_BASE_URL))
                 .authUrl(getRequired(AUTH_URL))
-                .clientId(getRequired(CLIENT_ID))
-                .clientSecret(getRequired(CLIENT_SECRET));
+                .clientId(getRequired(API_KEY, LEGACY_CLIENT_ID));
 
+        getOptional(CLIENT_SECRET).ifPresent(builder::clientSecret);
         getOptional(SCOPE).ifPresent(builder::scope);
         getOptional(MODEL).ifPresent(builder::model);
+        getOptional(CERT_FILE).ifPresent(builder::certificateFile);
+        getOptional(KEY_FILE).ifPresent(builder::keyFile);
+        getOptional(CA_FILE).ifPresent(builder::caFile);
 
         builder.retryPolicy(new RetryPolicy(5, Duration.ofSeconds(1), Duration.ofSeconds(60), 2.0));
         builder.connectTimeout(Duration.ofSeconds(10));
         return builder.build();
     }
 
-    private static String getRequired(String key) {
-        return Optional.ofNullable(System.getenv(key))
-                .or(() -> Optional.ofNullable(System.getProperty(key)))
-                .orElseThrow(() -> new IllegalStateException("Missing configuration key: " + key));
+    private static String getRequired(String key, String... fallbacks) {
+        return findValue(key, fallbacks)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Missing configuration key. Checked: " + joinKeys(key, fallbacks)));
     }
 
-    private static Optional<String> getOptional(String key) {
+    private static Optional<String> getOptional(String key, String... fallbacks) {
+        return findValue(key, fallbacks);
+    }
+
+    private static Optional<String> findValue(String key, String... fallbacks) {
+        Optional<String> value = resolveValue(key);
+        if (value.isPresent()) {
+            return value;
+        }
+        for (String fallback : fallbacks) {
+            value = resolveValue(fallback);
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> resolveValue(String key) {
         return Optional.ofNullable(System.getenv(key))
-                .or(() -> Optional.ofNullable(System.getProperty(key)));
+                .or(() -> Optional.ofNullable(System.getProperty(key)))
+                .or(() -> Optional.ofNullable(GRADLE_PROPERTIES.getProperty(key)))
+                .filter(value -> !value.isBlank());
+    }
+
+    private static String joinKeys(String key, String... fallbacks) {
+        if (fallbacks == null || fallbacks.length == 0) {
+            return key;
+        }
+        String[] keys = new String[fallbacks.length + 1];
+        keys[0] = key;
+        System.arraycopy(fallbacks, 0, keys, 1, fallbacks.length);
+        return String.join(", ", keys);
+    }
+
+    private static Properties loadGradleProperties() {
+        Properties properties = new Properties();
+        Path path = Paths.get("gradle.properties");
+        if (!Files.exists(path)) {
+            return properties;
+        }
+        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read gradle.properties", e);
+        }
+        return properties;
     }
 }


### PR DESCRIPTION
## Summary
- add default GigaChat credentials placeholders to gradle.properties
- allow GigachatClientProperties to read configuration from gradle.properties and use the new environment variable names
- expose optional certificate configuration on GigachatClientConfig and update documentation for the new settings

## Testing
- `gradle test` *(fails: 403 Forbidden while downloading dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f14f7f2483208743c6fe0d245118