### PR TITLE
Fix CLI packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ export GIGACHAT_CA_FILE="/path/to/ca.pem"
 2. Запустите CLI, указав путь к проекту, для которого нужно сгенерировать тесты:
 
    ```bash
-   java -cp build/libs/gigachat.tests.generator-1.0-SNAPSHOT.jar \
-     com.example.tests.generator.cli.TestGeneratorCli \
+   java -jar build/libs/gigachat-tests-generator-1.0-SNAPSHOT.jar \
      --project /path/to/target-project \
      --limit 10 \
      --max-retries 2
@@ -84,8 +83,7 @@ export GIGACHAT_CA_FILE="/path/to/ca.pem"
 2. Запускаем генератор (предполагается, что репозиторий агента находится рядом):
 
    ```bash
-   java -cp ../gigachat.tests.generator/build/libs/gigachat.tests.generator-1.0-SNAPSHOT.jar \
-     com.example.tests.generator.cli.TestGeneratorCli \
+   java -jar ../gigachat.tests.generator/build/libs/gigachat-tests-generator-1.0-SNAPSHOT.jar \
      --project $(pwd) \
      --class com.acme.discount.DiscountService
    ```

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,12 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
+tasks.named('jar') {
+    manifest {
+        attributes('Main-Class': 'com.example.tests.generator.cli.TestGeneratorCli')
+    }
+}
+
 def compilerExports = [
         '--add-exports', 'jdk.compiler/com.sun.source.util=ALL-UNNAMED',
         '--add-exports', 'jdk.compiler/com.sun.source.tree=ALL-UNNAMED',

--- a/src/main/java/com/example/tests/generator/cli/CliArguments.java
+++ b/src/main/java/com/example/tests/generator/cli/CliArguments.java
@@ -79,7 +79,7 @@ final class CliArguments {
     }
 
     public static void printUsage() {
-        System.out.println("Usage: java -jar tests-generator.jar [options]");
+        System.out.println("Usage: java -jar <path-to-generator-jar> [options]");
         System.out.println("Options:");
         System.out.println("  -p, --project <path>      Path to the project root (default: current directory)");
         System.out.println("  -c, --class <fqcn>        Fully qualified class name to target (may be repeated)");


### PR DESCRIPTION
## Summary
- declare the CLI entry point in the JAR manifest so `java -jar` works
- update the README examples to use the published artifact name and jar invocation
- clarify the CLI usage text to refer to a generic generator jar path

## Testing
- gradle jar --console=plain
- gradle test *(fails: Maven Central returned HTTP 403 while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fcaf342083209e00f94f21eeb29e