### PR TITLE
Add runnable discount-service demo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ export GIGACHAT_CA_FILE="/path/to/ca.pem"
 2. Запустите CLI, указав путь к проекту, для которого нужно сгенерировать тесты:
 
    ```bash
-   java -cp build/libs/gigachat.tests.generator-1.0-SNAPSHOT.jar \
-     com.example.tests.generator.cli.TestGeneratorCli \
+   java -jar build/libs/gigachat-tests-generator-1.0-SNAPSHOT.jar \
      --project /path/to/target-project \
      --limit 10 \
      --max-retries 2
@@ -72,32 +71,30 @@ export GIGACHAT_CA_FILE="/path/to/ca.pem"
 
 ## 3. Пример: покрываем сервис скидок
 
-Ниже — реальный сценарий запуска на небольшом проекте `discount-service`, который содержит класс `com.acme.discount.DiscountService` с логикой расчёта скидок.
+Ниже — реальный сценарий запуска на небольшом проекте `discount-service`, который содержится в каталоге [`examples/discount-service`](examples/discount-service) данного репозитория и включает класс `com.acme.discount.DiscountService` с логикой расчёта скидок.
 
-1. Клонируем проект и убеждаемся, что в нём есть Gradle wrapper:
+1. Открываем каталог примера:
 
    ```bash
-   git clone https://github.com/acme-labs/discount-service.git
-   cd discount-service
+   cd examples/discount-service
    ```
 
-2. Запускаем генератор (предполагается, что репозиторий агента находится рядом):
+2. Запускаем генератор (жар-файл берём из собранного артефакта в корне репозитория):
 
    ```bash
-   java -cp ../gigachat.tests.generator/build/libs/gigachat.tests.generator-1.0-SNAPSHOT.jar \
-     com.example.tests.generator.cli.TestGeneratorCli \
+   java -jar ../../build/libs/gigachat-tests-generator-1.0-SNAPSHOT.jar \
      --project $(pwd) \
      --class com.acme.discount.DiscountService
    ```
 
-3. Консольный вывод:
+3. Генератор сохранит тесты и выведет путь к Jacoco-отчёту:
 
    ```
    Tests generated successfully.
-   Coverage report: /home/user/discount-service/build/reports/jacoco/test/jacocoTestReport.xml
+   Coverage report: /path/to/examples/discount-service/build/reports/jacoco/test/jacocoTestReport.xml
    ```
 
-4. В каталоге `src/test/java/com/acme/discount` появился файл `DiscountServiceTest.java`. Его фрагмент:
+4. В каталоге `src/test/java/com/acme/discount` примера появился файл `DiscountServiceTest.java`. Его фрагмент:
 
    ```java
    package com.acme.discount;

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,12 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
+tasks.named('jar') {
+    manifest {
+        attributes('Main-Class': 'com.example.tests.generator.cli.TestGeneratorCli')
+    }
+}
+
 def compilerExports = [
         '--add-exports', 'jdk.compiler/com.sun.source.util=ALL-UNNAMED',
         '--add-exports', 'jdk.compiler/com.sun.source.tree=ALL-UNNAMED',

--- a/examples/discount-service/.gitignore
+++ b/examples/discount-service/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.gradle/

--- a/examples/discount-service/README.md
+++ b/examples/discount-service/README.md
@@ -1,0 +1,16 @@
+# Discount Service Demo
+
+Минимальный Gradle-проект, который использует генератор тестов.
+
+## Структура
+
+- `src/main/java/com/acme/discount/DiscountService.java` — простая бизнес-логика.
+- `build.gradle` — конфигурация Java 17 и JUnit 5, Jacoco-отчёт подключён к задаче `test`.
+
+## Запуск тестов
+
+```bash
+./gradlew --project-dir examples/discount-service test
+```
+
+Команда выше предполагает запуск из корня репозитория `gigachat.tests.generator` и использует уже настроенный Gradle Wrapper.

--- a/examples/discount-service/build.gradle
+++ b/examples/discount-service/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+    id 'jacoco'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy(tasks.named('jacocoTestReport'))
+}
+
+jacocoTestReport {
+    dependsOn(tasks.named('test'))
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+        html.required.set(false)
+    }
+}

--- a/examples/discount-service/settings.gradle
+++ b/examples/discount-service/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'discount-service'

--- a/examples/discount-service/src/main/java/com/acme/discount/DiscountService.java
+++ b/examples/discount-service/src/main/java/com/acme/discount/DiscountService.java
@@ -1,0 +1,19 @@
+package com.acme.discount;
+
+public class DiscountService {
+    private static final double LOYALTY_DISCOUNT = 0.10;
+
+    public double applyDiscount(double amount, boolean loyalCustomer) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("Amount must be non-negative");
+        }
+        if (loyalCustomer && amount > 0) {
+            return round(amount * (1 - LOYALTY_DISCOUNT));
+        }
+        return round(amount);
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+}

--- a/src/main/java/com/example/tests/generator/cli/CliArguments.java
+++ b/src/main/java/com/example/tests/generator/cli/CliArguments.java
@@ -79,7 +79,7 @@ final class CliArguments {
     }
 
     public static void printUsage() {
-        System.out.println("Usage: java -jar tests-generator.jar [options]");
+        System.out.println("Usage: java -jar <path-to-generator-jar> [options]");
         System.out.println("Options:");
         System.out.println("  -p, --project <path>      Path to the project root (default: current directory)");
         System.out.println("  -c, --class <fqcn>        Fully qualified class name to target (may be repeated)");


### PR DESCRIPTION
## Summary
- add a self-contained `examples/discount-service` Gradle project with a sample `DiscountService`
- ignore its build artifacts and document how to execute it with the existing Gradle wrapper
- update the README example to reference the bundled project instead of a non-existent Git repository

## Testing
- gradle jar --console=plain
- gradle test --console=plain *(fails: Maven Central responded with HTTP 403 while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fcaf342083209e00f94f21eeb29e