### PR TITLE
Add detailed logging and configurable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ export GIGACHAT_MODEL="GigaChat-2-Max"
 export GIGACHAT_CERT_FILE="/path/to/cert.pem"
 export GIGACHAT_KEY_FILE="/path/to/key.key"
 export GIGACHAT_CA_FILE="/path/to/ca.pem"
+# Управление уровнем логирования агента (необязательно, значения как у java.util.logging.Level)
+export GIGACHAT_AGENT_LOG_LEVEL="FINE"
 ```
 
 Переменные можно задать и через `-D`-параметры JVM (например, `-DGIGACHAT_API_BASE=...`) или поместить в `gradle.properties` проекта. При запуске токен автоматически кэшируется и переиспользуется до истечения срока действия.

--- a/src/main/java/com/example/tests/generator/build/ProjectBuildRunner.java
+++ b/src/main/java/com/example/tests/generator/build/ProjectBuildRunner.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -19,6 +20,7 @@ import java.util.regex.Pattern;
 public class ProjectBuildRunner {
 
     private static final Pattern ERROR_PATTERN = Pattern.compile("(?i)(error|failure|exception)");
+    private static final Logger LOGGER = Logger.getLogger(ProjectBuildRunner.class.getName());
 
     private final Path projectRoot;
     private final CommandExecutor commandExecutor;
@@ -35,8 +37,10 @@ public class ProjectBuildRunner {
     }
 
     public BuildResult runBuild() {
+        LOGGER.info("Determining build command");
         BuildCommand buildCommand = determineCommand();
         if (buildCommand == null) {
+            LOGGER.warning("Gradle wrapper not found. Cannot execute build.");
             List<String> errors = List.of("Не удалось найти Gradle wrapper (gradlew). Добавьте wrapper в проект, чтобы запускать тесты.");
             ErrorReport errorReport = new ErrorReport(Instant.now(), BuildTool.UNKNOWN, errors, "");
             return new BuildResult(BuildTool.UNKNOWN, false, "", errors, null, errorReport);
@@ -44,7 +48,9 @@ public class ProjectBuildRunner {
 
         CommandResult commandResult;
         try {
+            LOGGER.info(() -> "Executing build command: " + String.join(" ", buildCommand.command()));
             commandResult = commandExecutor.execute(buildCommand.command(), projectRoot);
+            LOGGER.info(() -> "Build command finished with exit code " + commandResult.exitCode());
         } catch (IOException e) {
             List<String> errors = List.of("Ошибка ввода-вывода при запуске сборки: " + e.getMessage());
             ErrorReport errorReport = new ErrorReport(Instant.now(), buildCommand.tool(), errors, "");
@@ -57,6 +63,7 @@ public class ProjectBuildRunner {
         }
 
         boolean success = commandResult.isSuccessful();
+        LOGGER.info(() -> "Build success: " + success);
         List<String> errors = success ? Collections.emptyList() : extractErrors(commandResult.output());
         CoverageSummary coverageSummary = success ? coverageAnalyzer.analyze(projectRoot).orElse(null) : null;
         ErrorReport errorReport = success ? null : new ErrorReport(Instant.now(), buildCommand.tool(), errors, commandResult.output());
@@ -68,10 +75,12 @@ public class ProjectBuildRunner {
         Path gradlew = projectRoot.resolve("gradlew");
         if (Files.exists(gradlew)) {
             gradlew.toFile().setExecutable(true);
+            LOGGER.info("Using Unix Gradle wrapper");
             return new BuildCommand(List.of("./gradlew", "test"), BuildTool.GRADLE);
         }
         Path gradlewBat = projectRoot.resolve("gradlew.bat");
         if (Files.exists(gradlewBat)) {
+            LOGGER.info("Using Windows Gradle wrapper");
             return new BuildCommand(List.of("gradlew.bat", "test"), BuildTool.GRADLE);
         }
         return null;

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -14,6 +14,7 @@ import com.example.tests.generator.validate.TestCodeParser;
 import com.example.tests.generator.validate.ValidationResult;
 import com.example.tests.generator.config.GigachatClientConfig;
 import com.example.tests.generator.config.GigachatClientProperties;
+import com.example.tests.generator.util.LoggingConfigurator;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -22,14 +23,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.logging.Logger;
 
 /**
  * Entry point for the Gigachat powered unit test generator.
  */
 public final class TestGeneratorCli {
 
+    private static final Logger LOGGER = Logger.getLogger(TestGeneratorCli.class.getName());
+
     public static void main(String[] args) {
         try {
+            LoggingConfigurator.configure();
             CliArguments arguments = CliArguments.parse(args);
             new TestGeneratorCli().run(arguments);
         } catch (CliArguments.HelpRequestedException ignored) {
@@ -43,6 +48,7 @@ public final class TestGeneratorCli {
 
     private void run(CliArguments arguments) throws IOException {
         Path projectRoot = arguments.projectRoot();
+        LOGGER.info(() -> "Starting test generation for project " + projectRoot);
         ProjectScanner scanner = new ProjectScanner(projectRoot);
         MetadataTransformer transformer = new MetadataTransformer();
         PromptBuilder promptBuilder = new PromptBuilder();
@@ -50,18 +56,23 @@ public final class TestGeneratorCli {
         TestCodeParser codeParser = new TestCodeParser();
         TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot);
 
+        LOGGER.info("Scanning project for candidate classes");
         List<ClassMetadata> discovered = scanner.scan();
+        LOGGER.info(() -> "Discovered " + discovered.size() + " classes in project");
         List<ClassMetadata> selected = filterTargets(discovered, arguments);
+        LOGGER.info(() -> "Selected " + selected.size() + " classes matching filters");
         if (selected.isEmpty()) {
             System.out.println("No matching classes found. Nothing to do.");
             return;
         }
 
+        LOGGER.info("Initializing Gigachat client");
         GigachatClientConfig config = GigachatClientProperties.load();
         LLMClient llmClient = new GigachatLLMClient(config);
 
         List<GeneratedTestClass> generatedClasses = new ArrayList<>();
         for (ClassMetadata metadata : selected.stream().limit(arguments.limit()).collect(Collectors.toList())) {
+            LOGGER.info(() -> "Generating tests for " + metadata.getQualifiedName());
             com.example.tests.generator.metadata.ClassMetadata promptMetadata = transformer.transform(metadata);
             String basePrompt = promptBuilder.buildPrompt(promptMetadata);
             String prompt = basePrompt;
@@ -69,51 +80,67 @@ public final class TestGeneratorCli {
             boolean success = false;
 
             for (int attempt = 0; attempt <= arguments.maxRetries(); attempt++) {
+                int attemptNumber = attempt + 1;
+                LOGGER.info(() -> String.format(Locale.ENGLISH,
+                        "Requesting Gigachat response (attempt %d/%d) for %s", attemptNumber,
+                        arguments.maxRetries() + 1, metadata.getQualifiedName()));
                 String response = llmClient.sendPrompt(prompt, defaultOptions());
+                LOGGER.fine(() -> "Received response from Gigachat for " + metadata.getQualifiedName());
                 pipeline.logGigachatExchange(prompt, response);
                 ValidationResult validationResult = responseValidator.validate(response);
+                LOGGER.info(() -> "Validation result for " + metadata.getQualifiedName() + ": "
+                        + (validationResult.isValid() ? "valid" : "invalid"));
                 if (validationResult.isValid() && validationResult.getSanitizedCode().isPresent()) {
                     boolean parsed = validationResult.getSanitizedCode()
                             .flatMap(codeParser::parse)
                             .map(generatedClasses::add)
                             .orElse(false);
                     if (parsed) {
+                        LOGGER.info(() -> "Successfully parsed generated tests for " + metadata.getQualifiedName());
                         success = true;
                         break;
                     }
                     feedback.add("LLM response did not contain parsable Java code");
+                    LOGGER.warning(() -> "Failed to parse generated code for " + metadata.getQualifiedName());
                 }
                 feedback.addAll(validationResult.getErrors());
                 prompt = promptBuilder.augmentWithFeedback(basePrompt, feedback);
+                LOGGER.info(() -> "Augmenting prompt with feedback for " + metadata.getQualifiedName());
             }
 
             if (!success) {
                 System.err.println("Unable to generate tests for " + metadata.getQualifiedName() + ":");
                 feedback.forEach(error -> System.err.println("  - " + error));
+                LOGGER.warning(() -> "Failed to generate tests for " + metadata.getQualifiedName());
             }
         }
 
         if (generatedClasses.isEmpty()) {
             System.err.println("No test classes were generated. Aborting.");
+            LOGGER.warning("No test classes generated");
             return;
         }
 
+        LOGGER.info("Persisting generated tests and validating build");
         GenerationReport report = pipeline.process(generatedClasses);
         if (report.isSuccessful()) {
             System.out.println("Tests generated successfully.");
             report.getCoverageSummary().ifPresent(summary -> System.out.printf(Locale.ENGLISH,
                     "Coverage report: %s%n", summary.getReportPath()));
+            LOGGER.info("Generation pipeline completed successfully");
         } else {
             System.err.println("Generated tests but build failed.");
             report.getErrorReport().ifPresent(errorReport -> {
                 System.err.println("Build tool: " + errorReport.getBuildTool());
                 errorReport.getErrors().forEach(line -> System.err.println("  - " + line));
             });
+            LOGGER.warning("Generated tests but build failed");
         }
 
         if (!report.getClassesWithoutTests().isEmpty()) {
             System.out.println("Classes still lacking tests:");
             report.getClassesWithoutTests().forEach(className -> System.out.println("  - " + className));
+            LOGGER.info(() -> "Classes without tests remaining: " + report.getClassesWithoutTests().size());
         }
     }
 

--- a/src/main/java/com/example/tests/generator/output/TestFileWriter.java
+++ b/src/main/java/com/example/tests/generator/output/TestFileWriter.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 /**
  * Persists generated test sources to the conventional test source set while respecting the
@@ -16,6 +17,7 @@ public class TestFileWriter {
 
     private final Path projectRoot;
     private final String testSourceSet;
+    private static final Logger LOGGER = Logger.getLogger(TestFileWriter.class.getName());
 
     public TestFileWriter(Path projectRoot) {
         this(projectRoot, DEFAULT_TEST_SOURCE_SET);
@@ -46,6 +48,14 @@ public class TestFileWriter {
         Path targetFile = targetDirectory.resolve(className + ".java");
         String normalizedSource = normalizeSource(packageName, sourceCode);
         Files.writeString(targetFile, normalizedSource, StandardCharsets.UTF_8);
+        Path relativePath;
+        try {
+            relativePath = projectRoot.relativize(targetFile);
+        } catch (IllegalArgumentException ignored) {
+            relativePath = targetFile;
+        }
+        Path finalRelativePath = relativePath;
+        LOGGER.info(() -> "Wrote generated test to " + finalRelativePath);
         return targetFile;
     }
 

--- a/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
+++ b/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
@@ -10,11 +10,14 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 /**
  * Coordinates writing generated tests to disk and validating them via the project build.
  */
 public class TestGenerationPipeline {
+
+    private static final Logger LOGGER = Logger.getLogger(TestGenerationPipeline.class.getName());
 
     private final TestFileWriter testFileWriter;
     private final ProjectBuildRunner buildRunner;
@@ -39,7 +42,12 @@ public class TestGenerationPipeline {
     }
 
     public GenerationReport process(List<GeneratedTestClass> generatedTests) throws IOException {
+        LOGGER.info("Writing generated test sources to disk");
         for (GeneratedTestClass generatedTest : generatedTests) {
+            LOGGER.info(() -> "Writing test class "
+                    + (generatedTest.getPackageName() == null || generatedTest.getPackageName().isBlank()
+                    ? generatedTest.getClassName()
+                    : generatedTest.getPackageName() + '.' + generatedTest.getClassName()));
             testFileWriter.writeTestFile(
                     generatedTest.getPackageName(),
                     generatedTest.getClassName(),
@@ -47,7 +55,10 @@ public class TestGenerationPipeline {
             );
         }
 
+        LOGGER.info("Running project build to validate generated tests");
         BuildResult buildResult = buildRunner.runBuild();
+        LOGGER.info(() -> "Build finished with status: " + (buildResult.isSuccessful() ? "SUCCESS" : "FAILURE"));
+        LOGGER.info("Checking for classes without generated tests");
         List<String> classesWithoutTests = classWithoutTestsDetector.detect();
         return new GenerationReport(buildResult, classesWithoutTests, auditLogger.snapshot());
     }

--- a/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
+++ b/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
@@ -57,7 +57,7 @@ public class TestGenerationPipeline {
 
         LOGGER.info("Running project build to validate generated tests");
         BuildResult buildResult = buildRunner.runBuild();
-        LOGGER.info(() -> "Build finished with status: " + (buildResult.isSuccessful() ? "SUCCESS" : "FAILURE"));
+        LOGGER.info(() -> "Build finished with status: " + (buildResult.isSuccess() ? "SUCCESS" : "FAILURE"));
         LOGGER.info("Checking for classes without generated tests");
         List<String> classesWithoutTests = classWithoutTestsDetector.detect();
         return new GenerationReport(buildResult, classesWithoutTests, auditLogger.snapshot());

--- a/src/main/java/com/example/tests/generator/service/GigachatTestGenerationAgent.java
+++ b/src/main/java/com/example/tests/generator/service/GigachatTestGenerationAgent.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.logging.Logger;
 
 /**
  * Coordinates the prompts sent to Gigachat to convert metadata into test suites.
@@ -18,6 +19,7 @@ public class GigachatTestGenerationAgent {
 
     private final LLMClient llmClient;
     private final PromptFactory promptFactory;
+    private static final Logger LOGGER = Logger.getLogger(GigachatTestGenerationAgent.class.getName());
 
     public GigachatTestGenerationAgent(LLMClient llmClient, PromptFactory promptFactory) {
         this.llmClient = Objects.requireNonNull(llmClient, "llmClient");
@@ -28,18 +30,24 @@ public class GigachatTestGenerationAgent {
         Objects.requireNonNull(metadata, "metadata");
 
         // Step 1: ask for analysis
+        LOGGER.info(() -> "Requesting analysis for " + metadata.className());
         String analysisPrompt = promptFactory.buildAnalysisPrompt(metadata);
         String analysis = llmClient.sendPrompt(analysisPrompt, defaultOptions());
+        LOGGER.info(() -> "Received analysis for " + metadata.className());
 
         // Step 2: ask for draft tests using streaming to provide immediate feedback
+        LOGGER.info(() -> "Requesting draft tests for " + metadata.className());
         String draftPrompt = promptFactory.buildTestDraftPrompt(metadata, analysis);
         List<String> streamed = llmClient.streamResponses(draftPrompt, streamOptions())
                 .collect(Collectors.toList());
         String draft = String.join("", streamed);
+        LOGGER.info(() -> "Draft test generation completed for " + metadata.className());
 
         // Step 3: optionally refine
+        LOGGER.info(() -> "Requesting refinement for " + metadata.className());
         String refinementPrompt = promptFactory.buildRefinementPrompt(metadata, draft);
         String refinement = llmClient.sendPrompt(refinementPrompt, defaultOptions());
+        LOGGER.info(() -> "Refinement completed for " + metadata.className());
 
         List<String> chunks = new ArrayList<>(streamed);
         chunks.add("\nRefinement summary:\n" + refinement);

--- a/src/main/java/com/example/tests/generator/service/GigachatTestGenerationAgent.java
+++ b/src/main/java/com/example/tests/generator/service/GigachatTestGenerationAgent.java
@@ -30,24 +30,24 @@ public class GigachatTestGenerationAgent {
         Objects.requireNonNull(metadata, "metadata");
 
         // Step 1: ask for analysis
-        LOGGER.info(() -> "Requesting analysis for " + metadata.className());
+        LOGGER.info(() -> "Requesting analysis for " + metadata.getQualifiedName());
         String analysisPrompt = promptFactory.buildAnalysisPrompt(metadata);
         String analysis = llmClient.sendPrompt(analysisPrompt, defaultOptions());
-        LOGGER.info(() -> "Received analysis for " + metadata.className());
+        LOGGER.info(() -> "Received analysis for " + metadata.getQualifiedName());
 
         // Step 2: ask for draft tests using streaming to provide immediate feedback
-        LOGGER.info(() -> "Requesting draft tests for " + metadata.className());
+        LOGGER.info(() -> "Requesting draft tests for " + metadata.getQualifiedName());
         String draftPrompt = promptFactory.buildTestDraftPrompt(metadata, analysis);
         List<String> streamed = llmClient.streamResponses(draftPrompt, streamOptions())
                 .collect(Collectors.toList());
         String draft = String.join("", streamed);
-        LOGGER.info(() -> "Draft test generation completed for " + metadata.className());
+        LOGGER.info(() -> "Draft test generation completed for " + metadata.getQualifiedName());
 
         // Step 3: optionally refine
-        LOGGER.info(() -> "Requesting refinement for " + metadata.className());
+        LOGGER.info(() -> "Requesting refinement for " + metadata.getQualifiedName());
         String refinementPrompt = promptFactory.buildRefinementPrompt(metadata, draft);
         String refinement = llmClient.sendPrompt(refinementPrompt, defaultOptions());
-        LOGGER.info(() -> "Refinement completed for " + metadata.className());
+        LOGGER.info(() -> "Refinement completed for " + metadata.getQualifiedName());
 
         List<String> chunks = new ArrayList<>(streamed);
         chunks.add("\nRefinement summary:\n" + refinement);

--- a/src/main/java/com/example/tests/generator/util/LoggingConfigurator.java
+++ b/src/main/java/com/example/tests/generator/util/LoggingConfigurator.java
@@ -1,0 +1,48 @@
+package com.example.tests.generator.util;
+
+import java.util.Locale;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+/**
+ * Configures {@link java.util.logging} levels based on environment variables.
+ */
+public final class LoggingConfigurator {
+
+    private static final String ENV_LOG_LEVEL = "GIGACHAT_AGENT_LOG_LEVEL";
+    private static final Level DEFAULT_LEVEL = Level.INFO;
+
+    private LoggingConfigurator() {
+    }
+
+    /**
+     * Configures the root logger level from the {@value #ENV_LOG_LEVEL} environment variable.
+     */
+    public static void configure() {
+        Level level = parseLevel(System.getenv(ENV_LOG_LEVEL));
+        Logger rootLogger = LogManager.getLogManager().getLogger("");
+        if (rootLogger != null) {
+            rootLogger.setLevel(level);
+            for (Handler handler : rootLogger.getHandlers()) {
+                handler.setLevel(level);
+            }
+        }
+        Logger.getLogger(LoggingConfigurator.class.getName()).log(Level.FINE,
+                () -> "Logging configured with level " + level);
+    }
+
+    private static Level parseLevel(String value) {
+        if (value == null || value.isBlank()) {
+            return DEFAULT_LEVEL;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        try {
+            return Level.parse(normalized);
+        } catch (IllegalArgumentException ex) {
+            System.err.println("Unknown log level '" + value + "'. Falling back to " + DEFAULT_LEVEL + '.');
+            return DEFAULT_LEVEL;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a LoggingConfigurator that configures java.util.logging from the GIGACHAT_AGENT_LOG_LEVEL environment variable
- extend the CLI, pipeline and supporting services with detailed INFO logging for each generation step and file/build operations
- document the new logging environment variable in the README for easier discovery

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d41fc132e0832095cb40b864b99568