### PR TITLE
Support legacy test source layouts

### DIFF
--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -8,6 +8,8 @@ import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
 import com.example.tests.generator.pipeline.GenerationReport;
 import com.example.tests.generator.pipeline.TestGenerationPipeline;
+import com.example.tests.generator.project.ProjectLayout;
+import com.example.tests.generator.project.ProjectLayoutResolver;
 import com.example.tests.generator.prompt.PromptBuilder;
 import com.example.tests.generator.scanner.ProjectScanner;
 import com.example.tests.generator.validate.ResponseValidator;
@@ -51,12 +53,13 @@ public final class TestGeneratorCli {
     private void run(CliArguments arguments) throws IOException {
         Path projectRoot = arguments.projectRoot();
         LOGGER.info(() -> "Starting test generation for project " + projectRoot);
-        ProjectScanner scanner = new ProjectScanner(projectRoot);
+        ProjectLayout projectLayout = ProjectLayoutResolver.detect(projectRoot);
+        ProjectScanner scanner = new ProjectScanner(projectRoot, projectLayout);
         MetadataTransformer transformer = new MetadataTransformer();
         PromptBuilder promptBuilder = new PromptBuilder();
         ResponseValidator responseValidator = new ResponseValidator();
         TestCodeParser codeParser = new TestCodeParser();
-        TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot);
+        TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot, projectLayout);
 
         LOGGER.info("Scanning project for candidate classes");
         List<ClassMetadata> discovered = scanner.scan();

--- a/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
+++ b/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
@@ -5,6 +5,8 @@ import com.example.tests.generator.build.GradleTestDependencyInstaller;
 import com.example.tests.generator.build.ProjectBuildRunner;
 import com.example.tests.generator.gigachat.GigachatAuditLogger;
 import com.example.tests.generator.output.TestFileWriter;
+import com.example.tests.generator.project.ProjectLayout;
+import com.example.tests.generator.project.ProjectLayoutResolver;
 import com.example.tests.generator.reporting.ClassWithoutTestsDetector;
 
 import java.io.IOException;
@@ -27,10 +29,14 @@ public class TestGenerationPipeline {
     private final GigachatAuditLogger auditLogger;
 
     public TestGenerationPipeline(Path projectRoot) {
-        this(new TestFileWriter(projectRoot),
+        this(projectRoot, ProjectLayoutResolver.detect(projectRoot));
+    }
+
+    public TestGenerationPipeline(Path projectRoot, ProjectLayout layout) {
+        this(new TestFileWriter(projectRoot, layout.testSourceSet()),
                 new ProjectBuildRunner(projectRoot),
                 new GradleTestDependencyInstaller(projectRoot),
-                new ClassWithoutTestsDetector(projectRoot),
+                new ClassWithoutTestsDetector(projectRoot, layout.mainSourceSet(), layout.testSourceSet()),
                 new GigachatAuditLogger());
     }
 

--- a/src/main/java/com/example/tests/generator/project/ProjectLayout.java
+++ b/src/main/java/com/example/tests/generator/project/ProjectLayout.java
@@ -1,0 +1,14 @@
+package com.example.tests.generator.project;
+
+import java.util.Objects;
+
+/**
+ * Describes the resolved source set layout of a target project.
+ */
+public record ProjectLayout(String mainSourceSet, String testSourceSet) {
+
+    public ProjectLayout {
+        Objects.requireNonNull(mainSourceSet, "mainSourceSet");
+        Objects.requireNonNull(testSourceSet, "testSourceSet");
+    }
+}

--- a/src/main/java/com/example/tests/generator/project/ProjectLayoutResolver.java
+++ b/src/main/java/com/example/tests/generator/project/ProjectLayoutResolver.java
@@ -1,0 +1,56 @@
+package com.example.tests.generator.project;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detects the primary source and test directories of a project.
+ */
+public final class ProjectLayoutResolver {
+
+    public static final String DEFAULT_MAIN_SOURCE_SET = "src/main/java";
+    public static final String DEFAULT_TEST_SOURCE_SET = "src/test/java";
+
+    private static final List<String> MAIN_SOURCE_CANDIDATES = List.of(
+            "src/main/java",
+            "src/main",
+            "src"
+    );
+
+    private static final List<String> TEST_SOURCE_CANDIDATES = List.of(
+            "src/test/java",
+            "src/test",
+            "test",
+            "tests"
+    );
+
+    private ProjectLayoutResolver() {
+    }
+
+    public static ProjectLayout detect(Path projectRoot) {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        Path normalisedRoot = projectRoot.toAbsolutePath().normalize();
+        String main = findExisting(normalisedRoot, MAIN_SOURCE_CANDIDATES, DEFAULT_MAIN_SOURCE_SET);
+        String test = findExisting(normalisedRoot, TEST_SOURCE_CANDIDATES, DEFAULT_TEST_SOURCE_SET);
+        return new ProjectLayout(main, test);
+    }
+
+    private static String findExisting(Path root, List<String> candidates, String fallback) {
+        for (String candidate : candidates) {
+            if (exists(root.resolve(candidate))) {
+                return normalise(candidate);
+            }
+        }
+        return normalise(fallback);
+    }
+
+    private static boolean exists(Path path) {
+        return Files.exists(path) && Files.isDirectory(path);
+    }
+
+    private static String normalise(String path) {
+        return path.replace('\\', '/');
+    }
+}

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -2,6 +2,7 @@ package com.example.tests.generator.scanner;
 
 import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.model.MethodMetadata;
+import com.example.tests.generator.project.ProjectLayout;
 
 import javax.lang.model.element.Modifier;
 import javax.tools.Diagnostic;
@@ -62,14 +63,13 @@ public class ProjectScanner {
             "classes",
             "generated",
             "generated-sources",
-            "node_modules",
-            "test",
-            "tests"
+            "node_modules"
     );
 
     private final Path rootDirectory;
     private final Map<Path, CacheEntry> cache = new ConcurrentHashMap<>();
     private final Set<String> ignoredDirectories;
+    private final List<Path> ignoredAbsoluteDirectories;
     private final JavaCompiler compiler;
 
     public ProjectScanner() {
@@ -77,12 +77,21 @@ public class ProjectScanner {
     }
 
     public ProjectScanner(Path rootDirectory) {
-        this(rootDirectory, null);
+        this(rootDirectory, null, null);
+    }
+
+    public ProjectScanner(Path rootDirectory, ProjectLayout layout) {
+        this(rootDirectory, layout, null);
     }
 
     public ProjectScanner(Path rootDirectory, Set<String> ignoredDirectories) {
+        this(rootDirectory, null, ignoredDirectories);
+    }
+
+    public ProjectScanner(Path rootDirectory, ProjectLayout layout, Set<String> ignoredDirectories) {
         this.rootDirectory = Objects.requireNonNull(rootDirectory, "rootDirectory").toAbsolutePath().normalize();
         this.ignoredDirectories = normaliseIgnoredDirectories(ignoredDirectories);
+        this.ignoredAbsoluteDirectories = determineIgnoredDirectories(layout);
         this.compiler = ToolProvider.getSystemJavaCompiler();
         if (this.compiler == null) {
             throw new IllegalStateException("Java compiler is not available. Ensure a JDK is installed.");
@@ -140,6 +149,12 @@ public class ProjectScanner {
         if (dir == null || rootDirectory.equals(dir)) {
             return false;
         }
+        Path absolute = dir.toAbsolutePath().normalize();
+        for (Path ignored : ignoredAbsoluteDirectories) {
+            if (absolute.startsWith(ignored)) {
+                return true;
+            }
+        }
         Path relative;
         try {
             relative = rootDirectory.relativize(dir);
@@ -158,6 +173,25 @@ public class ProjectScanner {
     private boolean isJavaFile(Path file) {
         String fileName = file.getFileName() != null ? file.getFileName().toString() : "";
         return fileName.endsWith(".java");
+    }
+
+    private List<Path> determineIgnoredDirectories(ProjectLayout layout) {
+        if (layout == null) {
+            return List.of();
+        }
+        List<Path> result = new ArrayList<>();
+        addIfExists(result, layout.testSourceSet());
+        return List.copyOf(result);
+    }
+
+    private void addIfExists(List<Path> target, String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) {
+            return;
+        }
+        Path candidate = rootDirectory.resolve(relativePath).toAbsolutePath().normalize();
+        if (Files.exists(candidate)) {
+            target.add(candidate);
+        }
     }
 
     private List<ClassMetadata> parseJavaFile(Path file) {

--- a/src/test/java/com/example/tests/generator/output/TestFileWriterTest.java
+++ b/src/test/java/com/example/tests/generator/output/TestFileWriterTest.java
@@ -47,4 +47,18 @@ class TestFileWriterTest {
         String content = Files.readString(expected);
         assertFalse(content.contains("package"));
     }
+
+    @Test
+    void supportsLegacyTestSourceSet() throws IOException {
+        TestFileWriter writer = new TestFileWriter(tempDir, "src/test");
+        String code = "package mtd.abonent; class DeleteAutoTest {}";
+
+        Path path = writer.writeTestFile("mtd.abonent", "DeleteAutoTest", code);
+
+        Path expected = tempDir.resolve("src/test/mtd/abonent/DeleteAutoTest.java");
+        assertEquals(expected, path);
+        assertTrue(Files.exists(expected));
+        String content = Files.readString(expected);
+        assertTrue(content.contains("package mtd.abonent;"));
+    }
 }

--- a/src/test/java/com/example/tests/generator/project/ProjectLayoutResolverTest.java
+++ b/src/test/java/com/example/tests/generator/project/ProjectLayoutResolverTest.java
@@ -1,0 +1,35 @@
+package com.example.tests.generator.project;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectLayoutResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectsLegacyTestLayout() throws IOException {
+        Files.createDirectories(tempDir.resolve("src/main/java"));
+        Files.createDirectories(tempDir.resolve("src/test"));
+
+        ProjectLayout layout = ProjectLayoutResolver.detect(tempDir);
+
+        assertEquals("src/main/java", layout.mainSourceSet());
+        assertEquals("src/test", layout.testSourceSet());
+    }
+
+    @Test
+    void fallsBackToDefaultsWhenDirectoriesMissing() {
+        ProjectLayout layout = ProjectLayoutResolver.detect(tempDir);
+
+        assertEquals(ProjectLayoutResolver.DEFAULT_MAIN_SOURCE_SET, layout.mainSourceSet());
+        assertEquals(ProjectLayoutResolver.DEFAULT_TEST_SOURCE_SET, layout.testSourceSet());
+    }
+}

--- a/src/test/java/com/example/tests/generator/reporting/ClassWithoutTestsDetectorTest.java
+++ b/src/test/java/com/example/tests/generator/reporting/ClassWithoutTestsDetectorTest.java
@@ -36,4 +36,22 @@ class ClassWithoutTestsDetectorTest {
         assertTrue(missing.contains("com.example.app.Controller"));
         assertFalse(missing.contains("com.example.app.Service"));
     }
+
+    @Test
+    void supportsLegacyTestDirectory() throws IOException {
+        Path mainDir = tempDir.resolve("src/main/java/mtd/abonent");
+        Files.createDirectories(mainDir);
+        Path abonent = mainDir.resolve("DELETE_AUTO.java");
+        Files.writeString(abonent, "package mtd.abonent; class DELETE_AUTO {}");
+
+        Path testDir = tempDir.resolve("src/test/mtd/abonent");
+        Files.createDirectories(testDir);
+        Path abonentTest = testDir.resolve("DELETE_AUTOTEST.java");
+        Files.writeString(abonentTest, "package mtd.abonent; class DELETE_AUTOTEST {}");
+
+        ClassWithoutTestsDetector detector = new ClassWithoutTestsDetector(tempDir, "src/main/java", "src/test");
+        List<String> missing = detector.detect();
+
+        assertFalse(missing.contains("mtd.abonent.DELETE_AUTO"));
+    }
 }

--- a/src/test/java/com/example/tests/generator/scanner/ProjectScannerTest.java
+++ b/src/test/java/com/example/tests/generator/scanner/ProjectScannerTest.java
@@ -1,0 +1,49 @@
+package com.example.tests.generator.scanner;
+
+import com.example.tests.generator.project.ProjectLayout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProjectScannerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void scansClassesInsideTestPackages() throws IOException {
+        Path abonentDir = tempDir.resolve("src/main/java/mtd/abonent");
+        Files.createDirectories(abonentDir);
+        Files.writeString(abonentDir.resolve("DELETE_AUTO.java"),
+                "package mtd.abonent; class DELETE_AUTO extends rt.Package {}");
+
+        Path legacyDir = tempDir.resolve("src/main/java/com/example/test");
+        Files.createDirectories(legacyDir);
+        Files.writeString(legacyDir.resolve("LegacyService.java"),
+                "package com.example.test; class LegacyService {}");
+
+        Path legacyTests = tempDir.resolve("src/test");
+        Files.createDirectories(legacyTests);
+        Files.writeString(legacyTests.resolve("LegacyServiceTest.java"),
+                "package com.example.test; class LegacyServiceTest {}");
+
+        ProjectLayout layout = new ProjectLayout("src/main/java", "src/test");
+        ProjectScanner scanner = new ProjectScanner(tempDir, layout);
+
+        List<com.example.tests.generator.model.ClassMetadata> classes = scanner.scan();
+
+        assertTrue(classes.stream()
+                .anyMatch(metadata -> "mtd.abonent.DELETE_AUTO".equals(metadata.getQualifiedName())));
+        assertTrue(classes.stream()
+                .anyMatch(metadata -> "com.example.test.LegacyService".equals(metadata.getQualifiedName())));
+        assertFalse(classes.stream()
+                .anyMatch(metadata -> "com.example.test.LegacyServiceTest".equals(metadata.getQualifiedName())));
+    }
+}


### PR DESCRIPTION
## Summary
- detect project layouts to support legacy projects with tests stored outside of `src/test/java`
- update the scanning and pipeline components to honour the resolved source sets
- cover the new layout handling with unit tests, including legacy directory structures

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d5303a5e788320b49dfad19baae189