### PR TITLE
Fix Gigachat response parsing and refine agent logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .gradle/
 build/
+# Allow source packages named build
+!/src/main/java/com/example/tests/generator/build/
+!/src/main/java/com/example/tests/generator/build/**
 # Ignore Gradle wrapper binary
 gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/example/tests/generator/build/ProjectBuildRunner.java
+++ b/src/main/java/com/example/tests/generator/build/ProjectBuildRunner.java
@@ -37,7 +37,7 @@ public class ProjectBuildRunner {
     }
 
     public BuildResult runBuild() {
-        LOGGER.info("Determining build command");
+        LOGGER.fine("Determining build command");
         BuildCommand buildCommand = determineCommand();
         if (buildCommand == null) {
             LOGGER.warning("Gradle wrapper not found. Cannot execute build.");
@@ -48,9 +48,9 @@ public class ProjectBuildRunner {
 
         CommandResult commandResult;
         try {
-            LOGGER.info(() -> "Executing build command: " + String.join(" ", buildCommand.command()));
+            LOGGER.fine(() -> "Executing build command: " + String.join(" ", buildCommand.command()));
             commandResult = commandExecutor.execute(buildCommand.command(), projectRoot);
-            LOGGER.info(() -> "Build command finished with exit code " + commandResult.exitCode());
+            LOGGER.fine(() -> "Build command finished with exit code " + commandResult.exitCode());
         } catch (IOException e) {
             List<String> errors = List.of("Ошибка ввода-вывода при запуске сборки: " + e.getMessage());
             ErrorReport errorReport = new ErrorReport(Instant.now(), buildCommand.tool(), errors, "");
@@ -63,7 +63,7 @@ public class ProjectBuildRunner {
         }
 
         boolean success = commandResult.isSuccessful();
-        LOGGER.info(() -> "Build success: " + success);
+        LOGGER.fine(() -> "Build success: " + success);
         List<String> errors = success ? Collections.emptyList() : extractErrors(commandResult.output());
         CoverageSummary coverageSummary = success ? coverageAnalyzer.analyze(projectRoot).orElse(null) : null;
         ErrorReport errorReport = success ? null : new ErrorReport(Instant.now(), buildCommand.tool(), errors, commandResult.output());
@@ -75,12 +75,12 @@ public class ProjectBuildRunner {
         Path gradlew = projectRoot.resolve("gradlew");
         if (Files.exists(gradlew)) {
             gradlew.toFile().setExecutable(true);
-            LOGGER.info("Using Unix Gradle wrapper");
+            LOGGER.fine("Using Unix Gradle wrapper");
             return new BuildCommand(List.of("./gradlew", "test"), BuildTool.GRADLE);
         }
         Path gradlewBat = projectRoot.resolve("gradlew.bat");
         if (Files.exists(gradlewBat)) {
-            LOGGER.info("Using Windows Gradle wrapper");
+            LOGGER.fine("Using Windows Gradle wrapper");
             return new BuildCommand(List.of("gradlew.bat", "test"), BuildTool.GRADLE);
         }
         return null;

--- a/src/main/java/com/example/tests/generator/cli/CliArguments.java
+++ b/src/main/java/com/example/tests/generator/cli/CliArguments.java
@@ -69,7 +69,7 @@ final class CliArguments {
                     break;
                 case "--class":
                 case "-c":
-                    targets.add(requireValue(arg, args, ++i));
+                    targets.add(normalizeTarget(requireValue(arg, args, ++i)));
                     break;
                 case "--max-retries":
                     maxRetries = Integer.parseInt(requireValue(arg, args, ++i));
@@ -109,7 +109,7 @@ final class CliArguments {
         System.out.println("Usage: java -jar <path-to-generator-jar> [options]");
         System.out.println("Options:");
         System.out.println("  -p, --project <path>      Path to the project root (default: current directory)");
-        System.out.println("  -c, --class <fqcn>        Fully qualified class name to target (may be repeated)");
+        System.out.println("  -c, --class <name>        Fully qualified or simple class name (may be repeated)");
         System.out.println("      --max-retries <n>     Maximum prompt retries when validation fails (default: 2)");
         System.out.println("      --limit <n>           Limit the number of classes to process");
         System.out.println("      --gigachat-delay <s>  Delay between Gigachat requests in seconds");
@@ -122,6 +122,33 @@ final class CliArguments {
             throw new IllegalArgumentException("Missing value for " + flag);
         }
         return args[index];
+    }
+
+    private static String normalizeTarget(String value) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.isEmpty()) {
+            return trimmed;
+        }
+        String normalized = trimmed.replace('\\', '/');
+        if (normalized.endsWith(".java")) {
+            normalized = normalized.substring(0, normalized.length() - 5);
+        }
+        int srcIndex = normalized.indexOf("src/main/java/");
+        if (srcIndex >= 0) {
+            normalized = normalized.substring(srcIndex + "src/main/java/".length());
+        }
+        int testSrcIndex = normalized.indexOf("src/test/java/");
+        if (testSrcIndex >= 0) {
+            normalized = normalized.substring(testSrcIndex + "src/test/java/".length());
+        }
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        normalized = normalized.replace('/', '.');
+        if (normalized.startsWith(".")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
     }
 
     static final class HelpRequestedException extends RuntimeException {

--- a/src/main/java/com/example/tests/generator/cli/CliArguments.java
+++ b/src/main/java/com/example/tests/generator/cli/CliArguments.java
@@ -17,15 +17,17 @@ final class CliArguments {
     private final int limit;
     private final Duration requestDelay;
     private final boolean useTokenAuth;
+    private final boolean infoLogging;
 
     private CliArguments(Path projectRoot, List<String> targetClasses, int maxRetries, int limit,
-            Duration requestDelay, boolean useTokenAuth) {
+            Duration requestDelay, boolean useTokenAuth, boolean infoLogging) {
         this.projectRoot = projectRoot;
         this.targetClasses = List.copyOf(targetClasses);
         this.maxRetries = maxRetries;
         this.limit = limit;
         this.requestDelay = requestDelay;
         this.useTokenAuth = useTokenAuth;
+        this.infoLogging = infoLogging;
     }
 
     public Path projectRoot() {
@@ -52,6 +54,10 @@ final class CliArguments {
         return useTokenAuth;
     }
 
+    public boolean infoLogging() {
+        return infoLogging;
+    }
+
     public static CliArguments parse(String[] args) {
         Path project = Paths.get("").toAbsolutePath();
         List<String> targets = new ArrayList<>();
@@ -59,6 +65,7 @@ final class CliArguments {
         int limit = Integer.MAX_VALUE;
         Duration requestDelay = Duration.ZERO;
         boolean useToken = false;
+        boolean infoLogging = false;
 
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
@@ -93,6 +100,9 @@ final class CliArguments {
                 case "--token":
                     useToken = true;
                     break;
+                case "--info":
+                    infoLogging = true;
+                    break;
                 case "--help":
                 case "-h":
                     throw new HelpRequestedException();
@@ -102,7 +112,7 @@ final class CliArguments {
         }
 
         return new CliArguments(project.toAbsolutePath().normalize(), targets, maxRetries, limit,
-                requestDelay, useToken);
+                requestDelay, useToken, infoLogging);
     }
 
     public static void printUsage() {
@@ -114,6 +124,7 @@ final class CliArguments {
         System.out.println("      --limit <n>           Limit the number of classes to process");
         System.out.println("      --gigachat-delay <s>  Delay between Gigachat requests in seconds");
         System.out.println("      --token               Use OAuth token authentication instead of mTLS certificates");
+        System.out.println("      --info                Enable detailed agent logging");
         System.out.println("  -h, --help               Show this help message");
     }
 

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -52,7 +52,6 @@ public final class TestGeneratorCli {
 
     private void run(CliArguments arguments) throws IOException {
         Path projectRoot = arguments.projectRoot();
-        LOGGER.info(() -> "Starting test generation for project " + projectRoot);
         ProjectLayout projectLayout = ProjectLayoutResolver.detect(projectRoot);
         ProjectScanner scanner = new ProjectScanner(projectRoot, projectLayout);
         MetadataTransformer transformer = new MetadataTransformer();
@@ -61,32 +60,24 @@ public final class TestGeneratorCli {
         TestCodeParser codeParser = new TestCodeParser();
         TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot, projectLayout);
 
-        LOGGER.info("Scanning project for candidate classes");
         List<ClassMetadata> discovered = scanner.scan();
-        LOGGER.info(() -> "Discovered " + discovered.size() + " classes in project");
         List<ClassMetadata> selected = filterTargets(discovered, arguments);
-        LOGGER.info(() -> "Selected " + selected.size() + " classes matching filters");
         if (selected.isEmpty()) {
             System.out.println("No matching classes found. Nothing to do.");
             return;
         }
 
-        LOGGER.info("Initializing Gigachat client");
         GigachatClientConfig config = GigachatClientProperties.load();
         LLMClient llmClient = arguments.useTokenAuth()
                 ? new GigachatLLMClient(config)
                 : new GigaChatCertificateClient(config);
 
         Duration requestDelay = arguments.requestDelay();
-        if (!requestDelay.isZero()) {
-            LOGGER.info(() -> "Applying delay of " + requestDelay.toSeconds()
-                    + " seconds between Gigachat requests");
-        }
 
         List<GeneratedTestClass> generatedClasses = new ArrayList<>();
         long lastRequestAtNanos = -1L;
         for (ClassMetadata metadata : selected.stream().limit(arguments.limit()).collect(Collectors.toList())) {
-            LOGGER.info(() -> "Generating tests for " + metadata.getQualifiedName());
+            LOGGER.info(() -> "Обработка класса: " + metadata.getQualifiedName());
             com.example.tests.generator.metadata.ClassMetadata promptMetadata = transformer.transform(metadata);
             String basePrompt = promptBuilder.buildPrompt(promptMetadata);
             String prompt = basePrompt;
@@ -95,73 +86,62 @@ public final class TestGeneratorCli {
 
             for (int attempt = 0; attempt <= arguments.maxRetries(); attempt++) {
                 int attemptNumber = attempt + 1;
-                LOGGER.info(() -> String.format(Locale.ENGLISH,
-                        "Requesting Gigachat response (attempt %d/%d) for %s", attemptNumber,
-                        arguments.maxRetries() + 1, metadata.getQualifiedName()));
                 String currentPrompt = prompt;
-                LOGGER.fine(() -> "Gigachat request for " + metadata.getQualifiedName()
-                        + ":\n" + currentPrompt);
+                LOGGER.info(() -> String.format(Locale.ENGLISH,
+                        "Формирование запроса (%d/%d) для %s", attemptNumber,
+                        arguments.maxRetries() + 1, metadata.getQualifiedName()));
+                LOGGER.info(() -> "Запрос в Gigachat:\n" + currentPrompt);
                 applyRequestDelay(requestDelay, lastRequestAtNanos);
                 lastRequestAtNanos = System.nanoTime();
                 String response = llmClient.sendPrompt(currentPrompt, defaultOptions());
-                LOGGER.fine(() -> "Received response from Gigachat for " + metadata.getQualifiedName());
-                LOGGER.fine(() -> "Gigachat response for " + metadata.getQualifiedName()
-                        + ":\n" + response);
+                LOGGER.info(() -> "Ответ от Gigachat:\n" + response);
                 pipeline.logGigachatExchange(currentPrompt, response);
                 ValidationResult validationResult = responseValidator.validate(response);
-                LOGGER.info(() -> "Validation result for " + metadata.getQualifiedName() + ": "
-                        + (validationResult.isValid() ? "valid" : "invalid"));
+                validationResult.getSanitizedCode()
+                        .ifPresent(code -> LOGGER.info(() -> "Полученный код:\n" + code));
                 if (validationResult.isValid() && validationResult.getSanitizedCode().isPresent()) {
                     boolean parsed = validationResult.getSanitizedCode()
                             .flatMap(codeParser::parse)
                             .map(generatedClasses::add)
                             .orElse(false);
                     if (parsed) {
-                        LOGGER.info(() -> "Successfully parsed generated tests for " + metadata.getQualifiedName());
                         success = true;
                         break;
                     }
                     feedback.add("LLM response did not contain parsable Java code");
-                    LOGGER.warning(() -> "Failed to parse generated code for " + metadata.getQualifiedName());
                 }
                 feedback.addAll(validationResult.getErrors());
                 prompt = promptBuilder.augmentWithFeedback(basePrompt, feedback);
-                LOGGER.info(() -> "Augmenting prompt with feedback for " + metadata.getQualifiedName());
             }
 
             if (!success) {
                 System.err.println("Unable to generate tests for " + metadata.getQualifiedName() + ":");
                 feedback.forEach(error -> System.err.println("  - " + error));
-                LOGGER.warning(() -> "Failed to generate tests for " + metadata.getQualifiedName());
             }
         }
 
         if (generatedClasses.isEmpty()) {
             System.err.println("No test classes were generated. Aborting.");
-            LOGGER.warning("No test classes generated");
             return;
         }
 
-        LOGGER.info("Persisting generated tests and validating build");
         GenerationReport report = pipeline.process(generatedClasses);
         if (report.isSuccessful()) {
             System.out.println("Tests generated successfully.");
             report.getCoverageSummary().ifPresent(summary -> System.out.printf(Locale.ENGLISH,
                     "Coverage report: %s%n", summary.getReportPath()));
-            LOGGER.info("Generation pipeline completed successfully");
         } else {
             System.err.println("Generated tests but build failed.");
             report.getErrorReport().ifPresent(errorReport -> {
                 System.err.println("Build tool: " + errorReport.getBuildTool());
                 errorReport.getErrors().forEach(line -> System.err.println("  - " + line));
+                errorReport.getErrors().forEach(line -> LOGGER.severe(() -> "Компиляция: " + line));
             });
-            LOGGER.warning("Generated tests but build failed");
         }
 
         if (!report.getClassesWithoutTests().isEmpty()) {
             System.out.println("Classes still lacking tests:");
             report.getClassesWithoutTests().forEach(className -> System.out.println("  - " + className));
-            LOGGER.info(() -> "Classes without tests remaining: " + report.getClassesWithoutTests().size());
         }
     }
 
@@ -169,10 +149,27 @@ public final class TestGeneratorCli {
         if (arguments.targetClasses().isEmpty()) {
             return discovered;
         }
-        List<String> targets = arguments.targetClasses();
-        return discovered.stream()
-                .filter(metadata -> targets.contains(metadata.getQualifiedName()))
+        List<String> targets = arguments.targetClasses().stream()
+                .map(String::trim)
+                .filter(target -> !target.isEmpty())
                 .collect(Collectors.toList());
+        return discovered.stream()
+                .filter(metadata -> matchesTarget(metadata, targets))
+                .collect(Collectors.toList());
+    }
+
+    private boolean matchesTarget(ClassMetadata metadata, List<String> targets) {
+        String qualifiedName = metadata.getQualifiedName();
+        String simpleName = metadata.getClassName();
+        for (String target : targets) {
+            if (qualifiedName.equals(target)
+                    || simpleName.equals(target)
+                    || qualifiedName.endsWith('.' + target)
+                    || target.endsWith('.' + simpleName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Map<String, Object> defaultOptions() {

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -126,8 +126,9 @@ public final class TestGeneratorCli {
                 String status = success ? "тест создан" : "тест не создан";
                 System.out.printf(Locale.ROOT, "%s: %s%n", metadata.getQualifiedName(), status);
             } else {
+                boolean finalSuccess = success;
                 LOGGER.info(() -> String.format(Locale.ENGLISH, "%s: %s", metadata.getQualifiedName(),
-                        success ? "тест создан" : "тест не создан"));
+                        finalSuccess ? "тест создан" : "тест не создан"));
             }
         }
 

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -38,8 +38,8 @@ public final class TestGeneratorCli {
 
     public static void main(String[] args) {
         try {
-            LoggingConfigurator.configure();
             CliArguments arguments = CliArguments.parse(args);
+            LoggingConfigurator.configure(arguments.infoLogging());
             new TestGeneratorCli().run(arguments);
         } catch (CliArguments.HelpRequestedException ignored) {
             CliArguments.printUsage();
@@ -59,6 +59,8 @@ public final class TestGeneratorCli {
         ResponseValidator responseValidator = new ResponseValidator();
         TestCodeParser codeParser = new TestCodeParser();
         TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot, projectLayout);
+
+        boolean infoLogging = arguments.infoLogging();
 
         List<ClassMetadata> discovered = scanner.scan();
         List<ClassMetadata> selected = filterTargets(discovered, arguments);
@@ -83,6 +85,7 @@ public final class TestGeneratorCli {
             String prompt = basePrompt;
             List<String> feedback = new ArrayList<>();
             boolean success = false;
+            pipeline.resetAudit();
 
             for (int attempt = 0; attempt <= arguments.maxRetries(); attempt++) {
                 int attemptNumber = attempt + 1;
@@ -100,11 +103,11 @@ public final class TestGeneratorCli {
                 validationResult.getSanitizedCode()
                         .ifPresent(code -> LOGGER.info(() -> "Полученный код:\n" + code));
                 if (validationResult.isValid() && validationResult.getSanitizedCode().isPresent()) {
-                    boolean parsed = validationResult.getSanitizedCode()
+                    GeneratedTestClass parsedClass = validationResult.getSanitizedCode()
                             .flatMap(codeParser::parse)
-                            .map(generatedClasses::add)
-                            .orElse(false);
-                    if (parsed) {
+                            .orElse(null);
+                    if (parsedClass != null) {
+                        generatedClasses.add(parsedClass);
                         success = true;
                         break;
                     }
@@ -117,6 +120,14 @@ public final class TestGeneratorCli {
             if (!success) {
                 System.err.println("Unable to generate tests for " + metadata.getQualifiedName() + ":");
                 feedback.forEach(error -> System.err.println("  - " + error));
+            }
+
+            if (!infoLogging) {
+                String status = success ? "тест создан" : "тест не создан";
+                System.out.printf(Locale.ROOT, "%s: %s%n", metadata.getQualifiedName(), status);
+            } else {
+                LOGGER.info(() -> String.format(Locale.ENGLISH, "%s: %s", metadata.getQualifiedName(),
+                        success ? "тест создан" : "тест не создан"));
             }
         }
 

--- a/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
+++ b/src/main/java/com/example/tests/generator/pipeline/TestGenerationPipeline.java
@@ -53,12 +53,7 @@ public class TestGenerationPipeline {
     }
 
     public GenerationReport process(List<GeneratedTestClass> generatedTests) throws IOException {
-        LOGGER.info("Writing generated test sources to disk");
         for (GeneratedTestClass generatedTest : generatedTests) {
-            LOGGER.info(() -> "Writing test class "
-                    + (generatedTest.getPackageName() == null || generatedTest.getPackageName().isBlank()
-                    ? generatedTest.getClassName()
-                    : generatedTest.getPackageName() + '.' + generatedTest.getClassName()));
             testFileWriter.writeTestFile(
                     generatedTest.getPackageName(),
                     generatedTest.getClassName(),
@@ -66,20 +61,14 @@ public class TestGenerationPipeline {
             );
         }
 
-        LOGGER.info("Ensuring required test dependencies are present");
         dependencyInstaller.ensureTestDependencies();
 
-        LOGGER.info("Running project build to validate generated tests");
         BuildResult buildResult = buildRunner.runBuild();
-        LOGGER.info(() -> "Build finished with status: " + (buildResult.isSuccess() ? "SUCCESS" : "FAILURE"));
-        LOGGER.info("Checking for classes without generated tests");
         List<String> classesWithoutTests = classWithoutTestsDetector.detect();
         return new GenerationReport(buildResult, classesWithoutTests, auditLogger.snapshot());
     }
 
     public void logGigachatExchange(String request, String response) {
-        LOGGER.fine(() -> "Persisting Gigachat request:\n" + request);
-        LOGGER.fine(() -> "Persisting Gigachat response:\n" + response);
         auditLogger.log(request, response);
     }
 

--- a/src/main/java/com/example/tests/generator/util/JsonUtils.java
+++ b/src/main/java/com/example/tests/generator/util/JsonUtils.java
@@ -13,10 +13,14 @@ public final class JsonUtils {
     private JsonUtils() {
     }
 
-    private static final Pattern CONTENT_PATTERN = Pattern.compile("\\\"content\\\"\\s*:\\s*\\\"([^\\\"]*)\\\"");
+    private static final Pattern CONTENT_PATTERN = Pattern.compile(
+            "\\\"content\\\"\\s*:\\s*\\\"((?:\\\\.|[^\\\\\"])*)\\\"",
+            Pattern.DOTALL);
 
     public static String findString(String json, String key) {
-        Pattern pattern = Pattern.compile(String.format("\\\"%s\\\"\\s*:\\s*\\\"([^\\\"]*)\\\"", Pattern.quote(key)));
+        Pattern pattern = Pattern.compile(
+                String.format("\\\"%s\\\"\\s*:\\s*\\\"((?:\\\\.|[^\\\\\"])*)\\\"", Pattern.quote(key)),
+                Pattern.DOTALL);
         Matcher matcher = pattern.matcher(json);
         if (matcher.find()) {
             return unescape(matcher.group(1));

--- a/src/main/java/com/example/tests/generator/util/LoggingConfigurator.java
+++ b/src/main/java/com/example/tests/generator/util/LoggingConfigurator.java
@@ -20,8 +20,9 @@ public final class LoggingConfigurator {
     /**
      * Configures the root logger level from the {@value #ENV_LOG_LEVEL} environment variable.
      */
-    public static void configure() {
-        Level level = parseLevel(System.getenv(ENV_LOG_LEVEL));
+    public static void configure(boolean infoLogging) {
+        Level envLevel = parseLevel(System.getenv(ENV_LOG_LEVEL));
+        Level level = determineLevel(infoLogging, envLevel);
         Logger rootLogger = LogManager.getLogManager().getLogger("");
         if (rootLogger != null) {
             rootLogger.setLevel(level);
@@ -31,6 +32,10 @@ public final class LoggingConfigurator {
         }
         Logger.getLogger(LoggingConfigurator.class.getName()).log(Level.FINE,
                 () -> "Logging configured with level " + level);
+    }
+
+    public static void configure() {
+        configure(false);
     }
 
     private static Level parseLevel(String value) {
@@ -44,5 +49,12 @@ public final class LoggingConfigurator {
             System.err.println("Unknown log level '" + value + "'. Falling back to " + DEFAULT_LEVEL + '.');
             return DEFAULT_LEVEL;
         }
+    }
+
+    private static Level determineLevel(boolean infoLogging, Level envLevel) {
+        if (infoLogging) {
+            return envLevel.intValue() < Level.INFO.intValue() ? envLevel : Level.INFO;
+        }
+        return envLevel.intValue() > Level.WARNING.intValue() ? envLevel : Level.WARNING;
     }
 }


### PR DESCRIPTION
## Summary
- parse Gigachat responses without truncating escaped content
- trim agent logging to the requested lifecycle events and surface compilation failures
- normalize the --class argument to accept fully qualified names, simple names, and paths

## Testing
- ./gradlew test *(fails: gradle-wrapper.jar is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d65d582aa48320b11b5dea490f1f72