### PR TITLE
Prevent StackOverflowError when extracting choice content

### DIFF
--- a/src/main/java/com/example/tests/generator/util/JsonUtils.java
+++ b/src/main/java/com/example/tests/generator/util/JsonUtils.java
@@ -14,7 +14,7 @@ public final class JsonUtils {
     }
 
     private static final Pattern CONTENT_PATTERN = Pattern.compile(
-            "\\\"content\\\"\\s*:\\s*\\\"((?:\\\\.|[^\\\\\"])*)\\\"",
+            "\\\"content\\\"\\s*:\\s*\\\"((?:[^\\\"\\\\]|\\\\.)*+)\\\"",
             Pattern.DOTALL);
 
     public static String findString(String json, String key) {


### PR DESCRIPTION
## Summary
- replace the JSON content regex with a possessive quantifier to eliminate catastrophic backtracking

## Testing
- Unable to run ./gradlew test (missing gradle-wrapper.jar in repository)


------
https://chatgpt.com/codex/tasks/task_e_68d677ba73608320bf20f1c72a81b934