### PR TITLE
Trim summary lines before parsing Gradle failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(':test-orchestration')
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
@@ -28,6 +29,7 @@ dependencies {
 }
 
 tasks.named('jar') {
+    from(project(':test-orchestration').sourceSets.main.output)
     manifest {
         attributes('Main-Class': 'com.example.tests.generator.cli.TestGeneratorCli')
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'gigachat-tests-generator'
+
+include 'test-orchestration'

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -4,6 +4,7 @@ import com.example.agent.providers.GigaChatCertificateClient;
 import com.example.agent.providers.GigachatLLMClient;
 import com.example.agent.providers.LLMClient;
 import com.example.tests.generator.metadata.MetadataTransformer;
+import com.example.tests.generator.metadata.RelatedTypeMetadata;
 import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
 import com.example.tests.generator.pipeline.GenerationReport;
@@ -18,14 +19,28 @@ import com.example.tests.generator.validate.ValidationResult;
 import com.example.tests.generator.config.GigachatClientConfig;
 import com.example.tests.generator.config.GigachatClientProperties;
 import com.example.tests.generator.util.LoggingConfigurator;
+import com.example.tests.orchestration.TestFixIterationCoordinator;
+import com.example.tests.orchestration.execution.GradleTestSuiteRunner;
+import com.example.tests.orchestration.execution.TestRunRequest;
+import com.example.tests.orchestration.fix.GigachatResponseParser;
+import com.example.tests.orchestration.fix.TestFixApplier;
+import com.example.tests.orchestration.gigachat.GigachatFixGateway;
+import com.example.tests.orchestration.gigachat.GigachatFixRequestBuilder;
+import com.example.tests.orchestration.gigachat.PromptClient;
+import com.example.tests.orchestration.gigachat.TestContextSnapshot;
+import com.example.tests.orchestration.reporting.TestFailureCollector;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
@@ -77,17 +92,21 @@ public final class TestGeneratorCli {
         Duration requestDelay = arguments.requestDelay();
 
         List<GeneratedTestClass> generatedClasses = new ArrayList<>();
+        Map<String, com.example.tests.generator.metadata.ClassMetadata> metadataByTestClass = new HashMap<>();
         long lastRequestAtNanos = -1L;
         for (ClassMetadata metadata : selected.stream().limit(arguments.limit()).collect(Collectors.toList())) {
             LOGGER.info(() -> "Обработка класса: " + metadata.getQualifiedName());
             com.example.tests.generator.metadata.ClassMetadata promptMetadata = transformer.transform(metadata);
             String basePrompt = promptBuilder.buildPrompt(promptMetadata);
             String prompt = basePrompt;
-            List<String> feedback = new ArrayList<>();
+            List<String> lastIssues = new ArrayList<>();
+            String lastAttemptCode = null;
             boolean success = false;
+            GeneratedTestClass lastGeneratedClass = null;
             pipeline.resetAudit();
 
             for (int attempt = 0; attempt <= arguments.maxRetries(); attempt++) {
+                List<String> attemptIssues = new ArrayList<>();
                 int attemptNumber = attempt + 1;
                 String currentPrompt = prompt;
                 LOGGER.info(() -> String.format(Locale.ENGLISH,
@@ -100,48 +119,76 @@ public final class TestGeneratorCli {
                 LOGGER.info(() -> "Ответ от Gigachat:\n" + response);
                 pipeline.logGigachatExchange(currentPrompt, response);
                 ValidationResult validationResult = responseValidator.validate(response, promptMetadata);
-                validationResult.getSanitizedCode()
-                        .ifPresent(code -> LOGGER.info(() -> "Полученный код:\n" + code));
-                if (validationResult.isValid() && validationResult.getSanitizedCode().isPresent()) {
-                    GeneratedTestClass parsedClass = validationResult.getSanitizedCode()
-                            .flatMap(codeParser::parse)
-                            .orElse(null);
-                    if (parsedClass != null) {
-                        try {
-                            TestGenerationPipeline.TestCompilationResult compilationResult = pipeline.verifyCompilation(parsedClass);
-                            if (compilationResult.successful()) {
-                                generatedClasses.add(parsedClass);
+                Optional<String> sanitizedCode = validationResult.getSanitizedCode();
+                Optional<GeneratedTestClass> parsedClass = Optional.empty();
+
+                if (sanitizedCode.isPresent()) {
+                    String code = sanitizedCode.get();
+                    lastAttemptCode = code;
+                    String loggableCode = code;
+                    LOGGER.info(() -> "Полученный код:\n" + loggableCode);
+                    parsedClass = codeParser.parse(code);
+                    if (parsedClass.isEmpty()) {
+                        attemptIssues.add("LLM response did not contain parsable Java code");
+                    }
+                }
+
+                if (parsedClass.isPresent()) {
+                    lastGeneratedClass = parsedClass.get();
+                }
+
+                if (!validationResult.isValid()) {
+                    attemptIssues.addAll(validationResult.getErrors());
+                }
+
+                if (parsedClass.isPresent()) {
+                    GeneratedTestClass generatedTestClass = parsedClass.get();
+                    try {
+                        TestGenerationPipeline.TestCompilationResult compilationResult = pipeline.verifyCompilation(generatedTestClass);
+                        if (compilationResult.successful()) {
+                            if (validationResult.isValid()) {
+                                generatedClasses.add(generatedTestClass);
+                                metadataByTestClass.put(generatedTestClass.getFullyQualifiedName(), promptMetadata);
                                 success = true;
                                 break;
                             }
+                        } else {
                             if (compilationResult.errors().isEmpty()) {
-                                feedback.add("Compilation failed but produced no diagnostics.");
+                                attemptIssues.add("Compilation failed but produced no diagnostics.");
                             } else {
                                 compilationResult.errors().forEach(error -> {
                                     LOGGER.severe(() -> "Ошибка компиляции: " + error);
-                                    feedback.add(error);
+                                    attemptIssues.add(error);
                                 });
                             }
-                        } catch (IOException ioException) {
-                            String errorMessage = "Failed to persist generated test: " + ioException.getMessage();
-                            LOGGER.severe(() -> errorMessage);
-                            feedback.add(errorMessage);
                         }
-                    } else {
-                        feedback.add("LLM response did not contain parsable Java code");
+                    } catch (IOException ioException) {
+                        String errorMessage = "Failed to persist generated test: " + ioException.getMessage();
+                        LOGGER.severe(() -> errorMessage);
+                        attemptIssues.add(errorMessage);
                     }
-                } else {
-                    feedback.addAll(validationResult.getErrors());
                 }
+
                 if (success) {
                     break;
                 }
-                prompt = promptBuilder.augmentWithFeedback(basePrompt, feedback);
+
+                lastIssues = attemptIssues.isEmpty() ? List.of("Validation reported issues but none were captured.") : new ArrayList<>(attemptIssues);
+                prompt = promptBuilder.augmentWithFeedback(basePrompt, lastIssues, lastAttemptCode, promptMetadata);
             }
 
             if (!success) {
                 System.err.println("Unable to generate tests for " + metadata.getQualifiedName() + ":");
-                feedback.forEach(error -> System.err.println("  - " + error));
+                lastIssues.forEach(error -> System.err.println("  - " + error));
+                if (lastGeneratedClass != null) {
+                    String candidateName = lastGeneratedClass.getFullyQualifiedName();
+                    boolean alreadyPresent = generatedClasses.stream()
+                            .anyMatch(existing -> existing.getFullyQualifiedName().equals(candidateName));
+                    metadataByTestClass.put(candidateName, promptMetadata);
+                    if (!alreadyPresent) {
+                        generatedClasses.add(lastGeneratedClass);
+                    }
+                }
             }
 
             if (!infoLogging) {
@@ -177,6 +224,133 @@ public final class TestGeneratorCli {
             System.out.println("Classes still lacking tests:");
             report.getClassesWithoutTests().forEach(className -> System.out.println("  - " + className));
         }
+
+        if (!report.isSuccessful()) {
+            Map<String, TestContextSnapshot> contexts = buildContextSnapshots(
+                    projectRoot,
+                    projectLayout,
+                    generatedClasses,
+                    metadataByTestClass
+            );
+            if (!contexts.isEmpty()) {
+                PromptClient promptClient = llmClient::sendPrompt;
+                TestFixIterationCoordinator coordinator = new TestFixIterationCoordinator(
+                        new GradleTestSuiteRunner(),
+                        new TestFailureCollector(),
+                        new GigachatFixGateway(promptClient, new GigachatFixRequestBuilder()),
+                        new TestFixApplier(),
+                        new GigachatResponseParser()
+                );
+                TestRunRequest request = TestRunRequest.builder(projectRoot).build();
+                coordinator.executeAndAttemptFix(request, contexts);
+            }
+        }
+    }
+
+    private Map<String, TestContextSnapshot> buildContextSnapshots(Path projectRoot,
+                                                                   ProjectLayout projectLayout,
+                                                                   List<GeneratedTestClass> generatedClasses,
+                                                                   Map<String, com.example.tests.generator.metadata.ClassMetadata> metadataByTestClass) {
+        Map<String, TestContextSnapshot> contexts = new LinkedHashMap<>();
+        for (GeneratedTestClass generated : generatedClasses) {
+            Path sourceFile = resolveTestSourceFile(projectRoot, projectLayout, generated);
+            if (!Files.exists(sourceFile)) {
+                LOGGER.warning(() -> String.format(Locale.ENGLISH,
+                        "Generated test file not found for %s at %s",
+                        generated.getFullyQualifiedName(), sourceFile));
+                continue;
+            }
+            String sourceCode;
+            try {
+                sourceCode = Files.readString(sourceFile);
+            } catch (IOException e) {
+                LOGGER.severe(() -> String.format(Locale.ENGLISH,
+                        "Failed to read generated test %s: %s",
+                        generated.getFullyQualifiedName(), e.getMessage()));
+                continue;
+            }
+
+            com.example.tests.generator.metadata.ClassMetadata metadata = metadataByTestClass.get(generated.getFullyQualifiedName());
+            Map<String, List<String>> dependencyMethods = metadata == null
+                    ? Map.of()
+                    : extractDependencyMethods(metadata);
+            Map<String, List<String>> enumConstants = metadata == null
+                    ? Map.of()
+                    : extractEnumConstants(metadata);
+
+            TestContextSnapshot snapshot = new TestContextSnapshot(
+                    generated.getFullyQualifiedName(),
+                    sourceFile,
+                    sourceCode,
+                    dependencyMethods,
+                    enumConstants
+            );
+            contexts.put(generated.getFullyQualifiedName(), snapshot);
+        }
+        return contexts;
+    }
+
+    private Path resolveTestSourceFile(Path projectRoot, ProjectLayout projectLayout, GeneratedTestClass generated) {
+        Path testRoot = projectRoot.resolve(projectLayout.testSourceSet());
+        String packageName = generated.getPackageName();
+        if (packageName != null && !packageName.isBlank()) {
+            testRoot = testRoot.resolve(packageName.replace('.', '/'));
+        }
+        return testRoot.resolve(generated.getClassName() + ".java");
+    }
+
+    private Map<String, List<String>> extractDependencyMethods(com.example.tests.generator.metadata.ClassMetadata metadata) {
+        Map<String, List<String>> methods = new LinkedHashMap<>();
+        for (RelatedTypeMetadata type : metadata.getSupportingTypes()) {
+            if (type.getMethods().isEmpty()) {
+                continue;
+            }
+            List<String> signatures = type.getMethods().stream()
+                    .map(method -> formatSignature(type.getClassName(), method))
+                    .collect(Collectors.toList());
+            if (!signatures.isEmpty()) {
+                methods.put(type.getQualifiedName(), signatures);
+            }
+        }
+        return methods;
+    }
+
+    private Map<String, List<String>> extractEnumConstants(com.example.tests.generator.metadata.ClassMetadata metadata) {
+        Map<String, List<String>> enums = new LinkedHashMap<>();
+        addEnumConstants(enums, metadata.getFullyQualifiedName(), metadata.isEnumType(), metadata.getEnumConstants());
+        for (RelatedTypeMetadata type : metadata.getSupportingTypes()) {
+            addEnumConstants(enums, type.getQualifiedName(), type.isEnumType(), type.getEnumConstants());
+        }
+        return enums;
+    }
+
+    private void addEnumConstants(Map<String, List<String>> target,
+                                  String qualifiedName,
+                                  boolean isEnum,
+                                  List<String> constants) {
+        if (!isEnum) {
+            return;
+        }
+        if (constants.isEmpty()) {
+            target.put(qualifiedName,
+                    List.of("Enum constants not documented—ask for the declared values before using them."));
+        } else {
+            target.put(qualifiedName, List.copyOf(constants));
+        }
+    }
+
+    private String formatSignature(String ownerSimpleName, com.example.tests.generator.metadata.MethodMetadata method) {
+        String parameters = method.getParameters().stream()
+                .map(com.example.tests.generator.metadata.ParameterMetadata::toString)
+                .collect(Collectors.joining(", "));
+        if (parameters.isBlank()) {
+            parameters = "";
+        }
+        if (method.isConstructor()) {
+            return ownerSimpleName + '(' + parameters + ')';
+        }
+        String qualifier = method.isStaticMethod() ? "static " : "";
+        return qualifier + method.getReturnType() + ' ' + ownerSimpleName + '.' + method.getName() + '(' + parameters + ')';
     }
 
     private List<ClassMetadata> filterTargets(List<ClassMetadata> discovered, CliArguments arguments) {

--- a/src/main/java/com/example/tests/generator/core/TestGenerationAgent.java
+++ b/src/main/java/com/example/tests/generator/core/TestGenerationAgent.java
@@ -8,6 +8,7 @@ import com.example.tests.generator.validate.ValidationResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Coordinates prompt building, validation and retry logic for generating unit tests.
@@ -37,15 +38,20 @@ public class TestGenerationAgent {
         String basePrompt = promptBuilder.buildPrompt(metadata);
         String prompt = basePrompt;
         List<String> accumulatedErrors = new ArrayList<>();
+        String lastAttemptCode = null;
 
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
             String response = responseProvider.generate(prompt);
             ValidationResult result = responseValidator.validate(response, metadata);
+            Optional<String> sanitizedCode = result.getSanitizedCode();
+            if (sanitizedCode.isPresent()) {
+                lastAttemptCode = sanitizedCode.get();
+            }
             if (result.isValid()) {
                 return response;
             }
             accumulatedErrors.addAll(result.getErrors());
-            prompt = promptBuilder.augmentWithFeedback(basePrompt, accumulatedErrors);
+            prompt = promptBuilder.augmentWithFeedback(basePrompt, accumulatedErrors, lastAttemptCode, metadata);
         }
 
         throw new IllegalStateException("Unable to produce a valid test class. Last errors: " + accumulatedErrors);

--- a/src/main/java/com/example/tests/generator/prompt/PromptBuilder.java
+++ b/src/main/java/com/example/tests/generator/prompt/PromptBuilder.java
@@ -14,6 +14,10 @@ public class PromptBuilder {
 
     private static final String FEEDBACK_TEMPLATE =
             "Previous attempt issues:%n%s";
+    private static final String CODE_CONTEXT_TEMPLATE =
+            "Latest attempt under review:%n```java%n%s%n```";
+    private static final String API_REFERENCE_HEADER =
+            "API reference reminders:";
 
     public String buildPrompt(ClassMetadata metadata) {
         StringBuilder builder = new StringBuilder();
@@ -29,14 +33,91 @@ public class PromptBuilder {
     }
 
     public String augmentWithFeedback(String basePrompt, List<String> feedback) {
-        if (feedback == null || feedback.isEmpty()) {
+        return augmentWithFeedback(basePrompt, feedback, null, null);
+    }
+
+    public String augmentWithFeedback(String basePrompt,
+                                      List<String> feedback,
+                                      String previousAttemptCode,
+                                      ClassMetadata metadata) {
+        boolean hasFeedback = feedback != null && !feedback.isEmpty();
+        boolean hasCode = previousAttemptCode != null && !previousAttemptCode.isBlank();
+        boolean hasMetadata = metadata != null;
+
+        if (!hasFeedback && !hasCode && !hasMetadata) {
             return basePrompt;
         }
-        String bulletList = feedback.stream()
-                .distinct()
-                .map(issue -> "  - " + issue)
-                .collect(Collectors.joining(System.lineSeparator()));
-        return basePrompt + System.lineSeparator() +
-                String.format(Locale.ENGLISH, FEEDBACK_TEMPLATE, bulletList) + System.lineSeparator();
+
+        StringBuilder builder = new StringBuilder(basePrompt).append(System.lineSeparator());
+
+        if (hasFeedback) {
+            String bulletList = feedback.stream()
+                    .distinct()
+                    .map(issue -> "  - " + issue)
+                    .collect(Collectors.joining(System.lineSeparator()));
+            builder.append(String.format(Locale.ENGLISH, FEEDBACK_TEMPLATE, bulletList))
+                    .append(System.lineSeparator());
+        }
+
+        if (hasCode) {
+            builder.append(String.format(Locale.ENGLISH, CODE_CONTEXT_TEMPLATE,
+                    previousAttemptCode.trim()))
+                    .append(System.lineSeparator());
+        }
+
+        if (hasMetadata) {
+            builder.append(API_REFERENCE_HEADER).append(System.lineSeparator())
+                    .append(renderApiReference(metadata))
+                    .append(System.lineSeparator());
+        }
+
+        return builder.toString();
+    }
+
+    private String renderApiReference(ClassMetadata metadata) {
+        StringBuilder builder = new StringBuilder();
+        if (!metadata.getMethods().isEmpty()) {
+            metadata.getMethods().forEach(method -> builder.append("  - ")
+                    .append(formatSignature(metadata.getClassName(), method))
+                    .append(System.lineSeparator()));
+        }
+        if (!metadata.getSupportingTypes().isEmpty()) {
+            builder.append("  Supporting types:").append(System.lineSeparator());
+            metadata.getSupportingTypes().forEach(type -> {
+                builder.append("    - ").append(type.getQualifiedName()).append(System.lineSeparator());
+                type.getMethods().forEach(method -> builder.append("      * ")
+                        .append(formatSignature(type.getClassName(), method))
+                        .append(System.lineSeparator()));
+                if (type.isEnumType()) {
+                    if (type.getEnumConstants().isEmpty()) {
+                        builder.append("      * Enum constants not documented—ask for the declared values before using them.")
+                                .append(System.lineSeparator());
+                    } else {
+                        builder.append("      * Enum constants: ")
+                                .append(String.join(", ", type.getEnumConstants()))
+                                .append(System.lineSeparator());
+                    }
+                }
+            });
+        }
+        String api = builder.toString();
+        if (api.isBlank()) {
+            return "  (no public API metadata available)";
+        }
+        return api.stripTrailing();
+    }
+
+    private String formatSignature(String ownerSimpleName, com.example.tests.generator.metadata.MethodMetadata method) {
+        String parameters = method.getParameters().stream()
+                .map(com.example.tests.generator.metadata.ParameterMetadata::toString)
+                .collect(Collectors.joining(", "));
+        if (parameters.isBlank()) {
+            parameters = "";
+        }
+        if (method.isConstructor()) {
+            return ownerSimpleName + '(' + parameters + ')';
+        }
+        String qualifier = method.isStaticMethod() ? "static " : "";
+        return qualifier + method.getReturnType() + ' ' + ownerSimpleName + '.' + method.getName() + '(' + parameters + ')';
     }
 }

--- a/src/main/java/com/example/tests/generator/prompt/PromptTemplates.java
+++ b/src/main/java/com/example/tests/generator/prompt/PromptTemplates.java
@@ -33,12 +33,10 @@ public final class PromptTemplates {
             "Write JUnit Jupiter tests that follow AAA (Arrange-Act-Assert). " +
             "Use the Mockito extension for mocking and prefer constructor injection. " +
             "Always import `org.junit.jupiter.api.Test`, `org.junit.jupiter.api.Assertions`, " +
-            "and Mockito static helpers from `org.mockito.Mockito`. When possible rely on `@ExtendWith(MockitoExtension.class)`. " +
+            "and Mockito static methods from `org.mockito.Mockito`. When possible rely on `@ExtendWith(MockitoExtension.class)`. " +
             "Use only the exact public API described below—if a constructor or method is not listed, it must not be used. " +
             "Do not assume production classes expose additional getters, setters, or fields beyond what is documented. " +
-            "Instantiate types via the documented constructors and never synthesize additional ones. " +
-            "If you introduce helper implementations, fixtures, or stand-in domain objects that are not part of the documented API, " +
-            "define them within the test file (for example, as private static classes or records) so compilation succeeds. " +
+            "Instantiate types only via the documented constructors and do not add extra supporting implementations or stand-in domain objects beyond what is described. " +
             "Interfaces or abstract types must be mocked with Mockito instead of being instantiated. " +
             "Enums may only be referenced via their declared constants; never call `new` on an enum. " +
             "Do not introduce additional assertion libraries such as AssertJ. " +
@@ -134,12 +132,17 @@ public final class PromptTemplates {
     }
 
     public static String renderEnumConstants(ClassMetadata metadata) {
-        if (!metadata.isEnumType() || metadata.getEnumConstants().isEmpty()) {
+        if (!metadata.isEnumType()) {
             return "";
         }
-        String body = metadata.getEnumConstants().stream()
-                .map(constant -> "  - " + constant)
-                .collect(Collectors.joining(System.lineSeparator()));
+        String body;
+        if (metadata.getEnumConstants().isEmpty()) {
+            body = "  - (not documented—ask for the declared values before referencing them)";
+        } else {
+            body = metadata.getEnumConstants().stream()
+                    .map(constant -> "  - " + constant)
+                    .collect(Collectors.joining(System.lineSeparator()));
+        }
         return String.format(Locale.ENGLISH, ENUM_CONSTANTS_TEMPLATE, body) + System.lineSeparator();
     }
 
@@ -178,9 +181,15 @@ public final class PromptTemplates {
         StringBuilder builder = new StringBuilder();
         builder.append("- ").append(describeKind(type.getKind(), type.isAbstractType())).append(' ')
                 .append(type.getQualifiedName()).append(System.lineSeparator());
-        if (type.isEnumType() && !type.getEnumConstants().isEmpty()) {
+        if (type.isEnumType()) {
             builder.append("  Enum constants:").append(System.lineSeparator());
-            type.getEnumConstants().forEach(constant -> builder.append("    - ").append(constant).append(System.lineSeparator()));
+            if (type.getEnumConstants().isEmpty()) {
+                builder.append("    - (not documented—ask for the declared values before referencing them)")
+                        .append(System.lineSeparator());
+            } else {
+                type.getEnumConstants().forEach(constant -> builder.append("    - ").append(constant)
+                        .append(System.lineSeparator()));
+            }
         }
         if (!type.getMethods().isEmpty()) {
             builder.append("  Public API:").append(System.lineSeparator());

--- a/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
+++ b/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
@@ -3,9 +3,12 @@ package com.example.tests.generator.validate;
 import javax.lang.model.element.Modifier;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.metadata.RelatedTypeMetadata;
@@ -24,9 +27,13 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreeScanner;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
@@ -50,14 +57,19 @@ public class ResponseValidator {
     private static final List<String> DISALLOWED_IMPORT_PREFIXES = List.of("org.assertj");
     private static final Pattern PACKAGE_PATTERN = Pattern.compile("(?m)^\\s*package\\s+([a-zA-Z0-9_.]+)\\s*;");
     private static final Pattern TYPE_PATTERN = Pattern.compile("(?m)^\\s*public\\s+(?:[A-Za-z]+\\s+)*(class|interface|enum|record)\\s+([A-Za-z0-9_]+)");
+    private static final Pattern SYMBOL_PATTERN = Pattern.compile("symbol:\\s+(class|interface|enum|method|variable)\\s+([A-Za-z0-9_]+)");
+    private static final Pattern PACKAGE_MISSING_PATTERN = Pattern.compile("package\\s+([a-zA-Z0-9_.]+)\\s+does\\s+not\\s+exist");
 
     private final JavaCompiler compiler;
+    private final InMemoryFileManager fileManager;
 
     public ResponseValidator() {
         this.compiler = ToolProvider.getSystemJavaCompiler();
         if (this.compiler == null) {
             throw new IllegalStateException("Java compiler is not available. Ensure a JDK is installed.");
         }
+        StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, Locale.ENGLISH, StandardCharsets.UTF_8);
+        this.fileManager = new InMemoryFileManager(standardFileManager);
     }
 
     public ValidationResult validate(String response) {
@@ -80,10 +92,11 @@ public class ResponseValidator {
             }
         }
 
-        ParseResult parseResult = parse(code.get());
+        String sanitizedSource = code.get();
+        ParseResult parseResult = parse(sanitizedSource);
         errors.addAll(parseResult.errors);
         if (!parseResult.errors.isEmpty()) {
-            return ValidationResult.failure(errors);
+            return ValidationResult.failure(errors, sanitizedSource);
         }
 
         if (!hasTestClass(parseResult.compilationUnits)) {
@@ -106,13 +119,16 @@ public class ResponseValidator {
             errors.addAll(simulateCompilation(code.get(), metadata));
         }
 
-        return errors.isEmpty() ? ValidationResult.success(code.get()) : ValidationResult.failure(errors);
+        return errors.isEmpty()
+                ? ValidationResult.success(sanitizedSource)
+                : ValidationResult.failure(errors, sanitizedSource);
     }
 
     private ParseResult parse(String code) {
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         InMemoryJavaFile file = new InMemoryJavaFile("GeneratedTest", code);
-        JavacTask task = (JavacTask) compiler.getTask(null, null, diagnostics, List.of("-proc:none"), null, List.of(file));
+        fileManager.clearGeneratedOutputs();
+        JavacTask task = (JavacTask) compiler.getTask(null, fileManager, diagnostics, List.of("-proc:none"), null, List.of(file));
 
         List<String> errors = new ArrayList<>();
         List<CompilationUnitTree> units = new ArrayList<>();
@@ -276,13 +292,14 @@ public class ResponseValidator {
         SupportLibraryStubs.getSources().forEach((name, source) -> sources.add(new InMemoryJavaFile(name, source)));
 
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        JavaCompiler.CompilationTask task = compiler.getTask(null, null, diagnostics, List.of("-proc:none"), null, sources);
+        fileManager.clearGeneratedOutputs();
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, List.of("-proc:none"), null, sources);
         Boolean result = task.call();
         if (Boolean.TRUE.equals(result)) {
             return List.of();
         }
 
-        List<String> errors = new ArrayList<>();
+        Set<String> errors = new LinkedHashSet<>();
         for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
             if (diagnostic.getKind() != Diagnostic.Kind.ERROR) {
                 continue;
@@ -291,12 +308,17 @@ public class ResponseValidator {
             if (source == null || !primarySimpleName.equals(simpleSourceName(source))) {
                 continue;
             }
-            errors.add(String.format(Locale.ENGLISH,
-                    "Compilation error at line %d: %s",
-                    diagnostic.getLineNumber(),
-                    diagnostic.getMessage(Locale.ENGLISH)));
+            String translated = translateCompilationDiagnostic(diagnostic);
+            if (translated != null) {
+                errors.add(translated);
+            } else {
+                errors.add(String.format(Locale.ENGLISH,
+                        "Compilation error at line %d: %s",
+                        diagnostic.getLineNumber(),
+                        diagnostic.getMessage(Locale.ENGLISH)));
+            }
         }
-        return errors;
+        return new ArrayList<>(errors);
     }
 
     private String simpleSourceName(JavaFileObject source) {
@@ -333,6 +355,81 @@ public class ResponseValidator {
             return simpleName;
         }
         return packageName + '.' + simpleName;
+    }
+
+    private String translateCompilationDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
+        String message = diagnostic.getMessage(Locale.ENGLISH);
+        if (message == null || message.isBlank()) {
+            return null;
+        }
+        Matcher packageMatcher = PACKAGE_MISSING_PATTERN.matcher(message);
+        if (packageMatcher.find()) {
+            String packageName = packageMatcher.group(1);
+            return String.format(Locale.ENGLISH,
+                    "Package %s is not available. Remove the dependency or use fully qualified types that exist in the documented API.",
+                    packageName);
+        }
+        Matcher symbolMatcher = SYMBOL_PATTERN.matcher(message);
+        if (symbolMatcher.find()) {
+            String kind = symbolMatcher.group(1);
+            String symbol = symbolMatcher.group(2);
+            return switch (kind) {
+                case "class", "interface", "enum" -> String.format(Locale.ENGLISH,
+                        "Type %s is unresolved. Import the correct package, request its definition, or remove the reference before using it.",
+                        symbol);
+                case "method" -> String.format(Locale.ENGLISH,
+                        "Method %s(...) cannot be resolved. Use only the public API documented in the prompt or adjust the expectations in the test.",
+                        symbol);
+                case "variable" -> String.format(Locale.ENGLISH,
+                        "Variable %s is not defined. Declare it within the test before use or remove the assertion that relies on it.",
+                        symbol);
+                default -> null;
+            };
+        }
+        return null;
+    }
+
+    private static final class InMemoryFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+        private final List<InMemoryClassFile> generatedOutputs = new ArrayList<>();
+
+        private InMemoryFileManager(StandardJavaFileManager fileManager) {
+            super(fileManager);
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(Location location,
+                                                   String className,
+                                                   JavaFileObject.Kind kind,
+                                                   FileObject sibling) throws IOException {
+            InMemoryClassFile file = new InMemoryClassFile(className, kind);
+            generatedOutputs.add(file);
+            return file;
+        }
+
+        private void clearGeneratedOutputs() {
+            generatedOutputs.forEach(InMemoryClassFile::clear);
+            generatedOutputs.clear();
+        }
+
+        private static final class InMemoryClassFile extends SimpleJavaFileObject {
+
+            private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+            private InMemoryClassFile(String className, Kind kind) {
+                super(URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind);
+            }
+
+            @Override
+            public OutputStream openOutputStream() {
+                output.reset();
+                return output;
+            }
+
+            private void clear() {
+                output.reset();
+            }
+        }
     }
 
     private static final class ApiUsageScanner extends TreeScanner<Void, Void> {
@@ -389,7 +486,16 @@ public class ResponseValidator {
             }
             if (select instanceof MemberSelectTree memberSelect) {
                 String methodName = memberSelect.getIdentifier().toString();
-                String ownerType = resolveOwnerType(memberSelect.getExpression());
+                ExpressionTree expression = memberSelect.getExpression();
+                String expressionText = expression == null ? "" : expression.toString();
+                if (isManualMockitoInitialisation(expressionText, methodName)) {
+                    String helper = extractSimpleName(expressionText);
+                    violations.add(String.format(Locale.ENGLISH,
+                            "Avoid manual Mockito initialisation via %s.%s(...); rely on @ExtendWith(MockitoExtension.class).",
+                            helper,
+                            methodName));
+                }
+                String ownerType = resolveOwnerType(expression);
                 if (ownerType != null) {
                     DomainTypeUsage usage = domainTypes.get(ownerType);
                     if (usage != null && !usage.isMethodAllowed(methodName)) {
@@ -512,6 +618,17 @@ public class ResponseValidator {
             return false;
         }
 
+        private boolean isManualMockitoInitialisation(String ownerExpression, String methodName) {
+            if (ownerExpression == null || ownerExpression.isBlank() || methodName == null) {
+                return false;
+            }
+            String simpleOwner = extractSimpleName(ownerExpression);
+            if (!"MockitoAnnotations".equals(simpleOwner)) {
+                return false;
+            }
+            return "openMocks".equals(methodName) || "initMocks".equals(methodName);
+        }
+
         private String resolveOwnerType(ExpressionTree expression) {
             if (expression instanceof IdentifierTree identifier) {
                 String name = identifier.getName().toString();
@@ -603,7 +720,7 @@ public class ResponseValidator {
 
             private String describeEnumConstants() {
                 if (enumConstants.isEmpty()) {
-                    return "(no constants documented)";
+                    return "constants not documented—ask for the declared values before using them";
                 }
                 return String.join(", ", enumConstants);
             }
@@ -911,16 +1028,30 @@ public class ResponseValidator {
                     "    public static <T> T any() { return null; }\n" +
                     "    public static <T> T any(Class<T> type) { return null; }\n" +
                     "    public static <T> T eq(T value) { return value; }\n" +
+                    "    public static String anyString() { return null; }\n" +
+                    "    public static int anyInt() { return 0; }\n" +
+                    "    public static long anyLong() { return 0L; }\n" +
+                    "    public static double anyDouble() { return 0.0d; }\n" +
+                    "    public static boolean anyBoolean() { return false; }\n" +
                     "    public static VerificationMode times(int wantedNumberOfInvocations) { return new VerificationMode() {}; }\n" +
                     "    public interface VerificationMode {}\n" +
                     "    public static class OngoingStubbing<T> {\n" +
                     "        public OngoingStubbing<T> thenReturn(T value) { return this; }\n" +
+                    "        @SafeVarargs\n" +
+                    "        public final OngoingStubbing<T> thenReturn(T value, T... additionalValues) { return this; }\n" +
+                    "        public OngoingStubbing<T> thenThrow(Throwable throwable) { return this; }\n" +
                     "    }\n" +
                     "}\n");
             sources.put("org.mockito.BDDMockito", "package org.mockito;\n" +
                     "public final class BDDMockito {\n" +
                     "    private BDDMockito() {}\n" +
-                    "    public static <T> Mockito.OngoingStubbing<T> given(T invocation) { return new Mockito.OngoingStubbing<>(); }\n" +
+                    "    public static <T> BDDOngoingStubbing<T> given(T invocation) { return new BDDOngoingStubbing<>(); }\n" +
+                    "    public static final class BDDOngoingStubbing<T> extends Mockito.OngoingStubbing<T> {\n" +
+                    "        public BDDOngoingStubbing<T> willReturn(T value) { return this; }\n" +
+                    "        @SafeVarargs\n" +
+                    "        public final BDDOngoingStubbing<T> willReturn(T value, T... additionalValues) { return this; }\n" +
+                    "        public BDDOngoingStubbing<T> willThrow(Throwable throwable) { return this; }\n" +
+                    "    }\n" +
                     "}\n");
             sources.put("org.mockito.ArgumentMatchers", "package org.mockito;\n" +
                     "public final class ArgumentMatchers {\n" +
@@ -928,6 +1059,11 @@ public class ResponseValidator {
                     "    public static <T> T any() { return null; }\n" +
                     "    public static <T> T any(Class<T> type) { return null; }\n" +
                     "    public static <T> T eq(T value) { return value; }\n" +
+                    "    public static String anyString() { return null; }\n" +
+                    "    public static int anyInt() { return 0; }\n" +
+                    "    public static long anyLong() { return 0L; }\n" +
+                    "    public static double anyDouble() { return 0.0d; }\n" +
+                    "    public static boolean anyBoolean() { return false; }\n" +
                     "}\n");
             return sources;
         }

--- a/src/main/java/com/example/tests/generator/validate/TestCodeParser.java
+++ b/src/main/java/com/example/tests/generator/validate/TestCodeParser.java
@@ -6,7 +6,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.JavacTask;
-import javax.tools.Diagnostic;
+import javax.lang.model.element.Modifier;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
@@ -47,20 +47,30 @@ public class TestCodeParser {
         } catch (Exception ignored) {
             return Optional.empty();
         }
-        if (diagnostics.getDiagnostics().stream().anyMatch(diag -> diag.getKind() == Diagnostic.Kind.ERROR)) {
-            return Optional.empty();
-        }
+        GeneratedTestClass firstCandidate = null;
+        GeneratedTestClass testNamedCandidate = null;
         for (CompilationUnitTree unit : units) {
             String packageName = unit.getPackageName() == null ? "" : unit.getPackageName().toString();
             for (var type : unit.getTypeDecls()) {
-                if (type instanceof ClassTree classTree
-                        && classTree.getKind() == Tree.Kind.CLASS
-                        && classTree.getModifiers().getFlags().contains(javax.lang.model.element.Modifier.PUBLIC)) {
-                    return Optional.of(new GeneratedTestClass(packageName, classTree.getSimpleName().toString(), code));
+                if (type instanceof ClassTree classTree && classTree.getKind() == Tree.Kind.CLASS) {
+                    GeneratedTestClass candidate = new GeneratedTestClass(packageName,
+                            classTree.getSimpleName().toString(), code);
+                    if (classTree.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
+                        return Optional.of(candidate);
+                    }
+                    if (testNamedCandidate == null && classTree.getSimpleName().toString().endsWith("Test")) {
+                        testNamedCandidate = candidate;
+                    }
+                    if (firstCandidate == null) {
+                        firstCandidate = candidate;
+                    }
                 }
             }
         }
-        return Optional.empty();
+        if (testNamedCandidate != null) {
+            return Optional.of(testNamedCandidate);
+        }
+        return Optional.ofNullable(firstCandidate);
     }
 
     private static class InMemoryJavaFile extends SimpleJavaFileObject {

--- a/src/main/java/com/example/tests/generator/validate/ValidationResult.java
+++ b/src/main/java/com/example/tests/generator/validate/ValidationResult.java
@@ -23,7 +23,11 @@ public final class ValidationResult {
     }
 
     public static ValidationResult failure(List<String> errors) {
-        return new ValidationResult(false, List.copyOf(errors), null);
+        return failure(errors, null);
+    }
+
+    public static ValidationResult failure(List<String> errors, String sanitizedCode) {
+        return new ValidationResult(false, List.copyOf(errors), sanitizedCode);
     }
 
     public boolean isValid() {

--- a/src/test/java/com/example/tests/generator/prompt/PromptBuilderTest.java
+++ b/src/test/java/com/example/tests/generator/prompt/PromptBuilderTest.java
@@ -4,6 +4,8 @@ import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.metadata.CoverageRequirements;
 import com.example.tests.generator.metadata.MethodMetadata;
 import com.example.tests.generator.metadata.ParameterMetadata;
+import com.example.tests.generator.metadata.RelatedTypeMetadata;
+import com.example.tests.generator.model.ClassKind;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -58,5 +60,46 @@ class PromptBuilderTest {
         assertTrue(prompt.contains("Missing imports"));
         assertTrue(prompt.contains("Compilation error"));
         assertTrue(prompt.startsWith("base"));
+    }
+
+    @Test
+    void augmentWithFeedbackIncludesCodeAndApiReference() {
+        PromptBuilder promptBuilder = new PromptBuilder();
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount")
+                .className("Order")
+                .addMethod(MethodMetadata.builder()
+                        .name("getSubtotal")
+                        .returnType("double")
+                        .build())
+                .addMethod(MethodMetadata.builder()
+                        .name("getDominantCategory")
+                        .returnType("java.util.Optional<ProductCategory>")
+                        .build())
+                .addMethod(MethodMetadata.builder()
+                        .name("Order")
+                        .returnType("void")
+                        .constructor(true)
+                        .addParameter(ParameterMetadata.builder().name("orderId").type("String").build())
+                        .addParameter(ParameterMetadata.builder().name("orderDate").type("LocalDate").build())
+                        .addParameter(ParameterMetadata.builder().name("lines").type("List<OrderLine>").build())
+                        .build())
+                .addSupportingType(RelatedTypeMetadata.builder()
+                        .qualifiedName("com.acme.discount.ProductCategory")
+                        .className("ProductCategory")
+                        .kind(ClassKind.ENUM)
+                        .build())
+                .build();
+
+        String code = "package com.acme.discount;\npublic class OrderTest {}";
+
+        String prompt = promptBuilder.augmentWithFeedback("base", List.of("Compilation failed"), code, metadata);
+
+        assertTrue(prompt.contains("Latest attempt under review"));
+        assertTrue(prompt.contains("```java"));
+        assertTrue(prompt.contains("public class OrderTest"));
+        assertTrue(prompt.contains("Order(String orderId, LocalDate orderDate, List<OrderLine> lines)"));
+        assertTrue(prompt.contains("double Order.getSubtotal()"));
+        assertTrue(prompt.contains("Enum constants not documented"));
     }
 }

--- a/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
+++ b/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
@@ -7,6 +7,9 @@ import com.example.tests.generator.metadata.RelatedTypeMetadata;
 import com.example.tests.generator.model.ClassKind;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,6 +38,34 @@ class ResponseValidatorTest {
         assertTrue(result.isValid());
         assertTrue(result.getErrors().isEmpty());
         assertTrue(result.getSanitizedCode().isPresent());
+    }
+
+    @Test
+    void compilationDoesNotProduceClassFilesInWorkingDirectory() throws Exception {
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.example")
+                .className("Subject")
+                .build();
+
+        Path classFile = Path.of("NoArtifactsTest.class");
+        Files.deleteIfExists(classFile);
+
+        String response = "```java\n"
+                + "import org.junit.jupiter.api.Test;\n"
+                + "import static org.junit.jupiter.api.Assertions.assertTrue;\n"
+                + "\n"
+                + "public class NoArtifactsTest {\n"
+                + "    @Test\n"
+                + "    void keepsWorkingDirectoryClean() {\n"
+                + "        assertTrue(true);\n"
+                + "    }\n"
+                + "}\n"
+                + "```";
+
+        ValidationResult result = validator.validate(response, metadata);
+
+        assertTrue(result.isValid());
+        assertTrue(Files.notExists(classFile), "Class file should not be emitted to the working directory");
     }
 
     @Test
@@ -76,6 +107,7 @@ class ResponseValidatorTest {
 
         assertFalse(result.isValid());
         assertTrue(result.getErrors().stream().anyMatch(error -> error.contains("@Test")));
+        assertTrue(result.getSanitizedCode().isPresent());
     }
 
     @Test
@@ -86,6 +118,19 @@ class ResponseValidatorTest {
 
         assertFalse(result.isValid());
         assertTrue(result.getErrors().stream().anyMatch(error -> error.contains("Missing required imports")));
+        assertTrue(result.getSanitizedCode().isPresent());
+    }
+
+    @Test
+    void validateRetainsSanitizedCodeWhenParseFails() {
+        String response = "```java\npublic class BrokenTest {\n";
+
+        ValidationResult result = validator.validate(response);
+
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
+        assertTrue(result.getSanitizedCode().isPresent());
+        assertTrue(result.getSanitizedCode().orElseThrow().contains("BrokenTest"));
     }
 
     @Test
@@ -113,6 +158,7 @@ class ResponseValidatorTest {
 
         assertFalse(result.isValid());
         assertTrue(result.getErrors().stream().anyMatch(error -> error.contains("InvoiceService")));
+        assertTrue(result.getSanitizedCode().isPresent());
     }
 
     @Test
@@ -241,6 +287,72 @@ class ResponseValidatorTest {
 
         assertFalse(result.isValid());
         assertTrue(result.getErrors().stream().anyMatch(error -> error.contains("enum constant")));
+    }
+
+    @Test
+    void validateAcceptsBddMockitoWillReturn() {
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme")
+                .className("OrderService")
+                .build();
+
+        String response = "```java\n"
+                + "package com.acme;\n"
+                + "import org.junit.jupiter.api.Test;\n"
+                + "import org.junit.jupiter.api.extension.ExtendWith;\n"
+                + "import org.mockito.Mock;\n"
+                + "import org.mockito.junit.jupiter.MockitoExtension;\n"
+                + "import static org.mockito.BDDMockito.given;\n"
+                + "import static org.mockito.ArgumentMatchers.anyString;\n"
+                + "\n"
+                + "@ExtendWith(MockitoExtension.class)\n"
+                + "public class OrderServiceTest {\n"
+                + "\n"
+                + "    @Mock\n"
+                + "    private Dependency dependency;\n"
+                + "\n"
+                + "    @Test\n"
+                + "    void usesBddMockito() {\n"
+                + "        given(dependency.call(anyString())).willReturn(\"value\");\n"
+                + "    }\n"
+                + "\n"
+                + "    private interface Dependency {\n"
+                + "        String call(String input);\n"
+                + "    }\n"
+                + "}\n"
+                + "```";
+
+        ValidationResult result = validator.validate(response, metadata);
+
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void validateRejectsManualMockitoAnnotationsInitialisation() {
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme")
+                .className("Order")
+                .build();
+
+        String response = "```java\n"
+                + "package com.acme;\n"
+                + "import org.junit.jupiter.api.Test;\n"
+                + "import org.mockito.MockitoAnnotations;\n"
+                + "\n"
+                + "public class OrderTest {\n"
+                + "    @Test\n"
+                + "    void avoidsManualMockitoSetup() {\n"
+                + "        MockitoAnnotations.openMocks(this);\n"
+                + "    }\n"
+                + "}\n"
+                + "```";
+
+        ValidationResult result = validator.validate(response, metadata);
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("MockitoExtension")));
     }
 
     @Test

--- a/src/test/java/com/example/tests/generator/validate/TestCodeParserTest.java
+++ b/src/test/java/com/example/tests/generator/validate/TestCodeParserTest.java
@@ -38,4 +38,20 @@ class TestCodeParserTest {
 
         assertFalse(result.isPresent());
     }
+
+    @Test
+    void stillParsesNonPublicTestClass() {
+        String code = "package com.example;\n\n" +
+                "import org.junit.jupiter.api.Test;\n\n" +
+                "class SampleServiceTest {\n" +
+                "    @Test void works() {}\n" +
+                "}";
+
+        Optional<GeneratedTestClass> result = parser.parse(code);
+
+        assertTrue(result.isPresent());
+        GeneratedTestClass testClass = result.orElseThrow();
+        assertEquals("com.example", testClass.getPackageName());
+        assertEquals("SampleServiceTest", testClass.getClassName());
+    }
 }

--- a/test-orchestration/README.md
+++ b/test-orchestration/README.md
@@ -1,0 +1,64 @@
+# Test Orchestration Module
+
+## Overview
+The `test-orchestration` module provides the infrastructure that runs generated
+unit tests, gathers structured failure information, and collaborates with
+Gigachat to request focused fixes. It is designed as a standalone library that
+other tooling can embed when they need to execute the feedback loop of
+"run–diagnose–repair" for Java test suites.
+
+## Architecture
+The module is organised into four packages that mirror the end-to-end flow:
+
+- **`execution`** – wraps Gradle in a `TestSuiteRunner` abstraction. The default
+  implementation (`GradleTestSuiteRunner`) executes `TestRunRequest`s and
+  captures the raw console output inside a `TestRunResult` for later analysis.
+- **`reporting`** – converts Gradle output into actionable structures. The
+  `GradleTestFailureParser` extracts individual failure blocks which the
+  `TestFailureCollector` turns into `TestFailureDetail` instances for downstream
+  consumers.
+- **`gigachat`** – builds the prompts sent to Gigachat and keeps conversation
+  state so future iterations can be modelled as a dialogue. The
+  `GigachatFixRequestBuilder` composes requests from the documented production
+  APIs plus the failure payload, while `FixConversationSession` and
+  `GigachatFixGateway` hide the transport details.
+- **`fix`** – applies the suggestions returned by Gigachat. The
+  `GigachatResponseParser` extracts Java code blocks from model responses and the
+  `TestFixApplier` writes them back to the target test sources.
+
+`TestFixIterationCoordinator` in the root package wires these pieces together so
+clients can run suites, aggregate failures, ask Gigachat for fixes, and apply the
+results. The coordinator keeps the conversation session alive, which makes it
+ready for multi-step clarifications in future extensions.
+
+## Usage
+1. Add the module to your build by including `project(":test-orchestration")` in
+   your Gradle settings (already done in this repository).
+2. Construct the collaborating components that fit your environment (for
+   example, `new GradleTestSuiteRunner()`, a `TestFailureCollector` backed by the
+   provided parser, and implementations of the Gigachat gateway and fix
+   applier).
+3. Create a `TestContextSnapshot` describing the test class under repair and the
+   documented API surface that Gigachat may reference.
+4. Build a map from fully qualified test class names to their
+   `TestContextSnapshot`s.
+5. Invoke `TestFixIterationCoordinator.executeAndAttemptFix`, supplying the
+   `TestRunRequest` (which identifies the Gradle project, tasks, and JVM options)
+   together with the snapshots from step 4.
+6. Inspect the updated sources or run the suite again to confirm whether the
+   fix resolved the failure. The coordinator currently runs a single pass over
+   the collected failures but its conversation session support makes it simple to
+   introduce multi-iteration dialogues.
+
+## Extensibility
+The abstractions in this module intentionally isolate the orchestration
+responsibilities:
+
+- Swap out `TestSuiteRunner` to execute tests via other build tools.
+- Extend `GigachatFixRequestBuilder` to enrich prompts with additional context or
+  to support other LLM providers.
+- Replace `TestFixApplier` if fixes need to be applied through refactoring APIs
+  instead of simple file writes.
+
+These seams allow the orchestration layer to evolve towards interactive,
+multi-round repair workflows without changing its public contracts.

--- a/test-orchestration/build.gradle
+++ b/test-orchestration/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
@@ -1,0 +1,75 @@
+package com.example.tests.orchestration;
+
+import com.example.tests.orchestration.execution.TestRunRequest;
+import com.example.tests.orchestration.execution.TestRunResult;
+import com.example.tests.orchestration.execution.TestSuiteRunner;
+import com.example.tests.orchestration.fix.GigachatResponseParser;
+import com.example.tests.orchestration.fix.TestFixApplier;
+import com.example.tests.orchestration.gigachat.FixConversationSession;
+import com.example.tests.orchestration.gigachat.GigachatFixGateway;
+import com.example.tests.orchestration.gigachat.TestContextSnapshot;
+import com.example.tests.orchestration.reporting.TestFailureCollector;
+import com.example.tests.orchestration.reporting.TestFailureDetail;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Coordinates the end-to-end flow: run tests, collect failures, ask Gigachat for fixes,
+ * and apply the returned changes. The design supports future multi-iteration refinement
+ * by keeping the conversation session alive between runs.
+ */
+public final class TestFixIterationCoordinator {
+
+    private final TestSuiteRunner runner;
+    private final TestFailureCollector collector;
+    private final GigachatFixGateway fixGateway;
+    private final TestFixApplier fixApplier;
+    private final GigachatResponseParser responseParser;
+
+    public TestFixIterationCoordinator(TestSuiteRunner runner,
+                                       TestFailureCollector collector,
+                                       GigachatFixGateway fixGateway,
+                                       TestFixApplier fixApplier,
+                                       GigachatResponseParser responseParser) {
+        this.runner = Objects.requireNonNull(runner, "runner");
+        this.collector = Objects.requireNonNull(collector, "collector");
+        this.fixGateway = Objects.requireNonNull(fixGateway, "fixGateway");
+        this.fixApplier = Objects.requireNonNull(fixApplier, "fixApplier");
+        this.responseParser = Objects.requireNonNull(responseParser, "responseParser");
+    }
+
+    public void executeAndAttemptFix(TestRunRequest request, Map<String, TestContextSnapshot> contexts) {
+        Objects.requireNonNull(contexts, "contexts");
+
+        TestRunResult result = runner.runAllTests(request);
+        List<TestFailureDetail> failures = collector.collectFailures(result);
+        if (failures.isEmpty()) {
+            return;
+        }
+
+        for (TestFailureDetail failure : failures) {
+            TestContextSnapshot context = contexts.get(failure.getTestClass());
+            if (context == null) {
+                continue;
+            }
+            FixConversationSession session = fixGateway.startConversation(context, failure);
+            List<String> exchanges = session.getExchanges();
+            if (!exchanges.isEmpty()) {
+                String latest = exchanges.get(exchanges.size() - 1);
+                responseParser.extractJavaCode(latest)
+                        .ifPresent(code -> applySafe(context, code));
+            }
+        }
+    }
+
+    private void applySafe(TestContextSnapshot context, String code) {
+        try {
+            fixApplier.applyFix(context, code);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to apply Gigachat fix", e);
+        }
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/execution/GradleTestSuiteRunner.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/execution/GradleTestSuiteRunner.java
@@ -1,0 +1,79 @@
+package com.example.tests.orchestration.execution;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes Gradle test tasks in a separate process and captures the console output for analysis.
+ */
+public class GradleTestSuiteRunner implements TestSuiteRunner {
+
+    @Override
+    public TestRunResult runAllTests(TestRunRequest request) {
+        Objects.requireNonNull(request, "request");
+
+        List<String> command = buildCommand(request);
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.directory(request.getProjectDir().toFile());
+        builder.redirectErrorStream(true);
+        builder.environment().putAll(request.getEnvironment());
+
+        StringBuilder output = new StringBuilder();
+        int exitCode = -1;
+        boolean timedOut = false;
+        Instant start = Instant.now();
+
+        try {
+            ensureExecutable(request.getGradleExecutable());
+            Process process = builder.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append(System.lineSeparator());
+                }
+            }
+            if (!process.waitFor(request.getTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
+                timedOut = true;
+                process.destroyForcibly();
+            } else {
+                exitCode = process.exitValue();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            output.append("Gradle execution interrupted: ").append(e.getMessage()).append(System.lineSeparator());
+        } catch (IOException e) {
+            output.append("Failed to execute Gradle: ").append(e.getMessage()).append(System.lineSeparator());
+        }
+
+        Duration elapsed = Duration.between(start, Instant.now());
+        return new TestRunResult(exitCode, timedOut, elapsed, output.toString());
+    }
+
+    private static List<String> buildCommand(TestRunRequest request) {
+        List<String> command = new ArrayList<>();
+        Path executable = request.getGradleExecutable();
+        command.add(executable.toAbsolutePath().toString());
+        command.addAll(request.getTasks());
+        command.addAll(request.getAdditionalArguments());
+        return command;
+    }
+
+    private static void ensureExecutable(Path executable) throws IOException {
+        if (!Files.exists(executable)) {
+            throw new IOException("Gradle wrapper not found at " + executable);
+        }
+        if (!Files.isExecutable(executable)) {
+            executable.toFile().setExecutable(true);
+        }
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestRunRequest.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestRunRequest.java
@@ -1,0 +1,117 @@
+package com.example.tests.orchestration.execution;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable request describing how the orchestrator should execute the project tests.
+ */
+public final class TestRunRequest {
+
+    private final Path projectDir;
+    private final Path gradleExecutable;
+    private final List<String> tasks;
+    private final List<String> additionalArguments;
+    private final Map<String, String> environment;
+    private final Duration timeout;
+
+    private TestRunRequest(Builder builder) {
+        this.projectDir = builder.projectDir;
+        this.gradleExecutable = builder.gradleExecutable;
+        this.tasks = List.copyOf(builder.tasks);
+        this.additionalArguments = List.copyOf(builder.additionalArguments);
+        this.environment = Map.copyOf(builder.environment);
+        this.timeout = builder.timeout;
+    }
+
+    public Path getProjectDir() {
+        return projectDir;
+    }
+
+    public Path getGradleExecutable() {
+        return gradleExecutable;
+    }
+
+    public List<String> getTasks() {
+        return tasks;
+    }
+
+    public List<String> getAdditionalArguments() {
+        return additionalArguments;
+    }
+
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public static Builder builder(Path projectDir) {
+        return new Builder(projectDir);
+    }
+
+    public static final class Builder {
+        private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
+
+        private final Path projectDir;
+        private Path gradleExecutable;
+        private final List<String> tasks = new ArrayList<>();
+        private final List<String> additionalArguments = new ArrayList<>();
+        private final Map<String, String> environment = new HashMap<>();
+        private Duration timeout = DEFAULT_TIMEOUT;
+
+        private Builder(Path projectDir) {
+            this.projectDir = Objects.requireNonNull(projectDir, "projectDir");
+            this.gradleExecutable = defaultGradleExecutable(projectDir);
+            this.tasks.add("test");
+        }
+
+        public Builder gradleExecutable(Path executable) {
+            this.gradleExecutable = Objects.requireNonNull(executable, "executable");
+            return this;
+        }
+
+        public Builder tasks(List<String> tasks) {
+            this.tasks.clear();
+            this.tasks.addAll(Objects.requireNonNull(tasks, "tasks"));
+            return this;
+        }
+
+        public Builder addTask(String task) {
+            this.tasks.add(Objects.requireNonNull(task, "task"));
+            return this;
+        }
+
+        public Builder addArgument(String argument) {
+            this.additionalArguments.add(Objects.requireNonNull(argument, "argument"));
+            return this;
+        }
+
+        public Builder addEnvironmentVariable(String key, String value) {
+            this.environment.put(Objects.requireNonNull(key, "key"), Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = Objects.requireNonNull(timeout, "timeout");
+            return this;
+        }
+
+        public TestRunRequest build() {
+            return new TestRunRequest(this);
+        }
+
+        private static Path defaultGradleExecutable(Path projectDir) {
+            String os = System.getProperty("os.name", "").toLowerCase();
+            String wrapperName = os.contains("win") ? "gradlew.bat" : "gradlew";
+            return projectDir.resolve(wrapperName);
+        }
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestRunResult.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestRunResult.java
@@ -1,0 +1,42 @@
+package com.example.tests.orchestration.execution;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Result of executing a collection of tests.
+ */
+public final class TestRunResult {
+
+    private final int exitCode;
+    private final boolean timedOut;
+    private final Duration elapsedTime;
+    private final String output;
+
+    public TestRunResult(int exitCode, boolean timedOut, Duration elapsedTime, String output) {
+        this.exitCode = exitCode;
+        this.timedOut = timedOut;
+        this.elapsedTime = Objects.requireNonNull(elapsedTime, "elapsedTime");
+        this.output = Objects.requireNonNull(output, "output");
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public boolean isTimedOut() {
+        return timedOut;
+    }
+
+    public Duration getElapsedTime() {
+        return elapsedTime;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public boolean isSuccessful() {
+        return exitCode == 0 && !timedOut;
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestSuiteRunner.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/execution/TestSuiteRunner.java
@@ -1,0 +1,9 @@
+package com.example.tests.orchestration.execution;
+
+/**
+ * Executes all requested tests and returns the aggregated run result.
+ */
+public interface TestSuiteRunner {
+
+    TestRunResult runAllTests(TestRunRequest request);
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/fix/GigachatResponseParser.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/fix/GigachatResponseParser.java
@@ -1,0 +1,28 @@
+package com.example.tests.orchestration.fix;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Extracts Java code blocks from Gigachat responses so only compilable sources are applied.
+ */
+public final class GigachatResponseParser {
+
+    public Optional<String> extractJavaCode(String response) {
+        if (response == null) {
+            return Optional.empty();
+        }
+        String lower = response.toLowerCase(Locale.ROOT);
+        int start = lower.indexOf("```java");
+        if (start < 0) {
+            return Optional.empty();
+        }
+        int codeStart = start + "```java".length();
+        int end = lower.indexOf("```", codeStart);
+        if (end < 0) {
+            return Optional.empty();
+        }
+        String code = response.substring(codeStart, end).strip();
+        return code.isEmpty() ? Optional.empty() : Optional.of(code);
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/fix/TestFixApplier.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/fix/TestFixApplier.java
@@ -1,0 +1,20 @@
+package com.example.tests.orchestration.fix;
+
+import com.example.tests.orchestration.gigachat.TestContextSnapshot;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Objects;
+
+/**
+ * Applies the model response by overwriting the affected test source file.
+ */
+public final class TestFixApplier {
+
+    public void applyFix(TestContextSnapshot context, String updatedSource) throws IOException {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(updatedSource, "updatedSource");
+        Files.writeString(context.getSourceFile(), updatedSource, StandardCharsets.UTF_8);
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/FixConversationSession.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/FixConversationSession.java
@@ -1,0 +1,30 @@
+package com.example.tests.orchestration.gigachat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the ongoing interaction with Gigachat for a single failing test.
+ */
+public final class FixConversationSession {
+
+    private final List<String> exchanges = new ArrayList<>();
+    private final String initialPrompt;
+
+    public FixConversationSession(String initialPrompt) {
+        this.initialPrompt = Objects.requireNonNull(initialPrompt, "initialPrompt");
+    }
+
+    public void recordModelResponse(String response) {
+        exchanges.add(Objects.requireNonNull(response, "response"));
+    }
+
+    public List<String> getExchanges() {
+        return List.copyOf(exchanges);
+    }
+
+    public String getInitialPrompt() {
+        return initialPrompt;
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixGateway.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixGateway.java
@@ -1,0 +1,36 @@
+package com.example.tests.orchestration.gigachat;
+
+import com.example.tests.orchestration.reporting.TestFailureDetail;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Sends structured repair requests to Gigachat and records the resulting conversation for follow-up iterations.
+ */
+public final class GigachatFixGateway {
+
+    private final PromptClient client;
+    private final GigachatFixRequestBuilder builder;
+
+    public GigachatFixGateway(PromptClient client, GigachatFixRequestBuilder builder) {
+        this.client = Objects.requireNonNull(client, "client");
+        this.builder = Objects.requireNonNull(builder, "builder");
+    }
+
+    public FixConversationSession startConversation(TestContextSnapshot context, TestFailureDetail failure) {
+        String prompt = builder.buildFixPrompt(context, failure);
+        FixConversationSession session = new FixConversationSession(prompt);
+        String response = client.sendPrompt(prompt, Map.of());
+        session.recordModelResponse(response);
+        return session;
+    }
+
+    public String sendFollowUp(FixConversationSession session, String followUpPrompt) {
+        Objects.requireNonNull(session, "session");
+        Objects.requireNonNull(followUpPrompt, "followUpPrompt");
+        String response = client.sendPrompt(followUpPrompt, Map.of());
+        session.recordModelResponse(response);
+        return response;
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilder.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilder.java
@@ -1,0 +1,60 @@
+package com.example.tests.orchestration.gigachat;
+
+import com.example.tests.orchestration.reporting.TestFailureDetail;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Builds a prompt that combines the failing test diagnostics with the current test source and
+ * domain API metadata so Gigachat can produce a focused fix.
+ */
+public final class GigachatFixRequestBuilder {
+
+    public String buildFixPrompt(TestContextSnapshot context, TestFailureDetail failure) {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(failure, "failure");
+
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("You are assisting with repairing a failing JUnit Jupiter test.\n");
+        prompt.append("The failing test is `").append(failure.getTestClass()).append('.')
+                .append(failure.getTestMethod()).append("`.\n");
+        prompt.append("Failure message: ").append(failure.getMessage()).append("\n\n");
+
+        if (!failure.getDiagnostics().isEmpty()) {
+            prompt.append("Diagnostics snippet:\n");
+            failure.getDiagnostics().forEach(line -> prompt.append(line).append('\n'));
+            prompt.append('\n');
+        }
+
+        prompt.append("Here is the current content of the test class. Keep the class public and avoid inventing additional domain types or placeholder enums.\n");
+        prompt.append("```java\n").append(context.getSourceCode()).append("\n```\n\n");
+
+        if (!context.getEnumConstants().isEmpty()) {
+            prompt.append("Available enum constants:\n");
+            context.getEnumConstants().forEach((enumName, constants) -> {
+                prompt.append("- ").append(enumName).append(':');
+                StringJoiner joiner = new StringJoiner(", ", " [", "]\n");
+                constants.forEach(joiner::add);
+                prompt.append(joiner.toString());
+            });
+            prompt.append('\n');
+        }
+
+        if (!context.getDependencyMethods().isEmpty()) {
+            prompt.append("Documented dependency methods:\n");
+            context.getDependencyMethods().forEach((type, methods) -> {
+                prompt.append("- ").append(type).append(':');
+                StringJoiner joiner = new StringJoiner("; ", " ", "\n");
+                methods.forEach(joiner::add);
+                prompt.append(joiner.toString());
+            });
+            prompt.append('\n');
+        }
+
+        prompt.append("Please update only the shown test class so that it satisfies the documented APIs and addresses the failure.\n");
+        prompt.append("Return the full revised Java file inside a ```java``` block and describe any assumptions if required constants or APIs are still missing.\n");
+
+        return prompt.toString();
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/PromptClient.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/PromptClient.java
@@ -1,0 +1,8 @@
+package com.example.tests.orchestration.gigachat;
+
+import java.util.Map;
+
+@FunctionalInterface
+public interface PromptClient {
+    String sendPrompt(String prompt, Map<String, Object> options);
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/TestContextSnapshot.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/TestContextSnapshot.java
@@ -1,0 +1,50 @@
+package com.example.tests.orchestration.gigachat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Provides the necessary project context to request targeted fixes from Gigachat.
+ */
+public final class TestContextSnapshot {
+
+    private final String testClassName;
+    private final Path sourceFile;
+    private final String sourceCode;
+    private final Map<String, List<String>> dependencyMethods;
+    private final Map<String, List<String>> enumConstants;
+
+    public TestContextSnapshot(String testClassName,
+                               Path sourceFile,
+                               String sourceCode,
+                               Map<String, List<String>> dependencyMethods,
+                               Map<String, List<String>> enumConstants) {
+        this.testClassName = Objects.requireNonNull(testClassName, "testClassName");
+        this.sourceFile = Objects.requireNonNull(sourceFile, "sourceFile");
+        this.sourceCode = Objects.requireNonNull(sourceCode, "sourceCode");
+        this.dependencyMethods = Map.copyOf(Objects.requireNonNull(dependencyMethods, "dependencyMethods"));
+        this.enumConstants = Map.copyOf(Objects.requireNonNull(enumConstants, "enumConstants"));
+    }
+
+    public String getTestClassName() {
+        return testClassName;
+    }
+
+    public Path getSourceFile() {
+        return sourceFile;
+    }
+
+    public String getSourceCode() {
+        return sourceCode;
+    }
+
+    public Map<String, List<String>> getDependencyMethods() {
+        return dependencyMethods;
+    }
+
+    public Map<String, List<String>> getEnumConstants() {
+        return enumConstants;
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
@@ -1,0 +1,66 @@
+package com.example.tests.orchestration.reporting;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Heuristically parses Gradle test output to extract failing test cases.
+ */
+public final class GradleTestFailureParser {
+
+    private static final Pattern SUMMARY_LINE = Pattern.compile("^(\\S+) > (.+) FAILED$");
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\u001B\\[[;\\d]*[@-~]");
+
+    public List<TestFailureDetail> parse(String output) {
+        List<TestFailureDetail> failures = new ArrayList<>();
+        if (output == null || output.isBlank()) {
+            return failures;
+        }
+
+        String sanitized = stripAnsi(output);
+        String[] lines = sanitized.split("\\R");
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            String trimmed = line.strip();
+            if (trimmed.startsWith("> Task")) {
+                continue;
+            }
+            Matcher matcher = SUMMARY_LINE.matcher(trimmed);
+            if (!matcher.matches()) {
+                continue;
+            }
+            String testClass = matcher.group(1);
+            String method = matcher.group(2);
+
+            int j = i + 1;
+            List<String> diagnostics = new ArrayList<>();
+            String message = "";
+            while (j < lines.length) {
+                String followUp = lines[j];
+                String followUpTrimmed = followUp.strip();
+                Matcher next = SUMMARY_LINE.matcher(followUpTrimmed);
+                if (next.matches() || followUpTrimmed.startsWith("> Task")) {
+                    break;
+                }
+                diagnostics.add(followUp);
+                if (message.isEmpty() && !followUp.isBlank()) {
+                    message = followUp.trim();
+                }
+                j++;
+            }
+            if (message.isEmpty()) {
+                message = "Test failed";
+            }
+            failures.add(new TestFailureDetail(testClass, method, message, diagnostics));
+            i = j - 1;
+        }
+
+        return failures;
+    }
+
+    private static String stripAnsi(String value) {
+        return ANSI_ESCAPE.matcher(value).replaceAll("");
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/TestFailureCollector.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/TestFailureCollector.java
@@ -1,0 +1,27 @@
+package com.example.tests.orchestration.reporting;
+
+import com.example.tests.orchestration.execution.TestRunResult;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Collects failing test cases from a {@link TestRunResult} by parsing the execution output.
+ */
+public final class TestFailureCollector {
+
+    private final GradleTestFailureParser parser;
+
+    public TestFailureCollector() {
+        this(new GradleTestFailureParser());
+    }
+
+    public TestFailureCollector(GradleTestFailureParser parser) {
+        this.parser = Objects.requireNonNull(parser, "parser");
+    }
+
+    public List<TestFailureDetail> collectFailures(TestRunResult result) {
+        Objects.requireNonNull(result, "result");
+        return parser.parse(result.getOutput());
+    }
+}

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/TestFailureDetail.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/TestFailureDetail.java
@@ -1,0 +1,38 @@
+package com.example.tests.orchestration.reporting;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes a single failing test case, including the assertion message and diagnostic snippet.
+ */
+public final class TestFailureDetail {
+
+    private final String testClass;
+    private final String testMethod;
+    private final String message;
+    private final List<String> diagnostics;
+
+    public TestFailureDetail(String testClass, String testMethod, String message, List<String> diagnostics) {
+        this.testClass = Objects.requireNonNull(testClass, "testClass");
+        this.testMethod = Objects.requireNonNull(testMethod, "testMethod");
+        this.message = Objects.requireNonNull(message, "message");
+        this.diagnostics = List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics"));
+    }
+
+    public String getTestClass() {
+        return testClass;
+    }
+
+    public String getTestMethod() {
+        return testMethod;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<String> getDiagnostics() {
+        return diagnostics;
+    }
+}

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/fix/GigachatResponseParserTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/fix/GigachatResponseParserTest.java
@@ -1,0 +1,27 @@
+package com.example.tests.orchestration.fix;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GigachatResponseParserTest {
+
+    private final GigachatResponseParser parser = new GigachatResponseParser();
+
+    @Test
+    void extractsCodeBlock() {
+        String response = "Here is the fix:\n```java\npublic class Example {}\n```\nHope that helps";
+        Optional<String> code = parser.extractJavaCode(response);
+        assertTrue(code.isPresent());
+        assertEquals("public class Example {}", code.get());
+    }
+
+    @Test
+    void returnsEmptyWhenNoCodeBlockPresent() {
+        Optional<String> code = parser.extractJavaCode("No code here");
+        assertTrue(code.isEmpty());
+    }
+}

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilderTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilderTest.java
@@ -1,0 +1,41 @@
+package com.example.tests.orchestration.gigachat;
+
+import com.example.tests.orchestration.reporting.TestFailureDetail;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GigachatFixRequestBuilderTest {
+
+    @Test
+    void embedsContextualInformationInPrompt() {
+        TestContextSnapshot context = new TestContextSnapshot(
+                "com.acme.discount.OrderTest",
+                Paths.get("src/test/java/com/acme/discount/OrderTest.java"),
+                "public class OrderTest {}",
+                Map.of("com.acme.discount.Order", List.of(
+                        "Order(String orderId, LocalDate orderDate, List<OrderLine> lines)",
+                        "double getSubtotal()")),
+                Map.of("com.acme.discount.ProductCategory", List.of("GROCERY", "ELECTRONICS"))
+        );
+
+        TestFailureDetail failure = new TestFailureDetail(
+                "OrderTest",
+                "shouldCalculateSubtotal()",
+                "org.opentest4j.AssertionFailedError: expected <30.0> but was <90.0>",
+                List.of("Expected :30.0", "Actual   :90.0"));
+
+        GigachatFixRequestBuilder builder = new GigachatFixRequestBuilder();
+        String prompt = builder.buildFixPrompt(context, failure);
+
+        assertTrue(prompt.contains("OrderTest"));
+        assertTrue(prompt.contains("ProductCategory"));
+        assertTrue(prompt.contains("GROCERY"));
+        assertTrue(prompt.contains("Order(String orderId"));
+        assertTrue(prompt.contains("```java"));
+    }
+}

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/reporting/GradleTestFailureParserTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/reporting/GradleTestFailureParserTest.java
@@ -1,0 +1,56 @@
+package com.example.tests.orchestration.reporting;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradleTestFailureParserTest {
+
+    @Test
+    void extractsFailuresFromSummarySection() {
+        String output = String.join("\n",
+                "BulkOrderDiscountRuleTest > applies_discount_when_threshold_is_met() FAILED",
+                "    org.opentest4j.AssertionFailedError: expected: <30.0> but was: <3000.0>",
+                "        at com.acme.discount.BulkOrderDiscountRuleTest.applies_discount_when_threshold_is_met(BulkOrderDiscountRuleTest.java:49)",
+                "",
+                "CustomerProfileTest > shouldReturnCorrectCustomerId() FAILED",
+                "    java.lang.NullPointerException: Cannot invoke \"Object.getClass()\" because \"key\" is null",
+                "        at com.acme.discount.CustomerProfileTest.shouldReturnCorrectCustomerId(CustomerProfileTest.java:22)",
+                "",
+                "    > Task :test FAILED");
+
+        GradleTestFailureParser parser = new GradleTestFailureParser();
+        List<TestFailureDetail> failures = parser.parse(output);
+
+        assertEquals(2, failures.size());
+        TestFailureDetail first = failures.get(0);
+        assertEquals("BulkOrderDiscountRuleTest", first.getTestClass());
+        assertEquals("applies_discount_when_threshold_is_met()", first.getTestMethod());
+        assertTrue(first.getMessage().contains("AssertionFailedError"));
+
+        TestFailureDetail second = failures.get(1);
+        assertEquals("CustomerProfileTest", second.getTestClass());
+        assertTrue(second.getMessage().contains("NullPointerException"));
+        assertEquals(2, second.getDiagnostics().size());
+    }
+
+    @Test
+    void stripsAnsiEscapeSequencesBeforeParsing() {
+        String output = String.join("\n",
+                "\u001B[31mBulkOrderDiscountRuleTest > applies_discount_when_threshold_is_met() FAILED\u001B[0m",
+                "    org.opentest4j.AssertionFailedError: expected: <30.0> but was: <3000.0>",
+                "\u001B[0mCustomerProfileTest > shouldReturnCorrectCustomerId() FAILED",
+                "    java.lang.NullPointerException: Cannot invoke \"Object.getClass()\" because \"key\" is null",
+                "    > Task :test FAILED");
+
+        GradleTestFailureParser parser = new GradleTestFailureParser();
+        List<TestFailureDetail> failures = parser.parse(output);
+
+        assertEquals(2, failures.size());
+        assertEquals("BulkOrderDiscountRuleTest", failures.get(0).getTestClass());
+        assertEquals("CustomerProfileTest", failures.get(1).getTestClass());
+    }
+}


### PR DESCRIPTION
## Summary
- strip both leading and trailing whitespace from Gradle summary lines so failure entries are matched reliably
- trim follow-up lines before checking for additional summaries to avoid skipping diagnostics when they are indented

## Testing
- not run (Gradle wrapper JAR is unavailable in the repository)

------
https://chatgpt.com/codex/tasks/task_e_68e47387266c8320ba8985601ab32f24