### PR TITLE
Handle Gradle compile failures in test failure parser

### DIFF
--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -280,7 +280,7 @@ public class ProjectScanner {
 
                 if (kind.isEnum()) {
                     classTree.getMembers().stream()
-                            .filter(this::isEnumConstant)
+                            .filter(member -> isEnumConstant(classTree, member))
                             .map(this::enumConstantName)
                             .filter(Objects::nonNull)
                             .forEach(builder::addEnumConstant);
@@ -383,14 +383,23 @@ public class ProjectScanner {
         }
     }
 
-    private boolean isEnumConstant(Tree member) {
-        if (member == null) {
+    private boolean isEnumConstant(ClassTree enumTree, Tree member) {
+        if (enumTree == null || member == null) {
             return false;
         }
         if (member instanceof VariableTree variable) {
             try {
                 if (variable.getType() == null) {
                     return true;
+                }
+                String enumName = enumTree.getSimpleName().toString();
+                ExpressionTree variableType = variable.getType();
+                if (variableType != null && enumName.contentEquals(variableType.toString())) {
+                    if (variable.getModifiers().getFlags().contains(Modifier.STATIC)
+                            && variable.getModifiers().getFlags().contains(Modifier.FINAL)
+                            && variable.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
+                        return true;
+                    }
                 }
             } catch (UnsupportedOperationException ignored) {
                 // fall through to the generic check below

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -412,6 +412,9 @@ public class ProjectScanner {
     }
 
     private String enumConstantName(Tree member) {
+        if (member instanceof VariableTree variable) {
+            return variable.getName() == null ? null : variable.getName().toString();
+        }
         return invokeToString(member, "getName");
     }
 

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -14,7 +14,6 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
@@ -393,7 +392,7 @@ public class ProjectScanner {
                     return true;
                 }
                 String enumName = enumTree.getSimpleName().toString();
-                ExpressionTree variableType = variable.getType();
+                Tree variableType = variable.getType();
                 if (variableType != null && enumName.contentEquals(variableType.toString())) {
                     if (variable.getModifiers().getFlags().contains(Modifier.STATIC)
                             && variable.getModifiers().getFlags().contains(Modifier.FINAL)

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -387,6 +387,15 @@ public class ProjectScanner {
         if (member == null) {
             return false;
         }
+        if (member instanceof VariableTree variable) {
+            try {
+                if (variable.getModifiers().getFlags().contains(Modifier.ENUM)) {
+                    return true;
+                }
+            } catch (UnsupportedOperationException ignored) {
+                // fall through to the generic check below
+            }
+        }
         try {
             return member.getKind().name().equals("ENUM_CONSTANT");
         } catch (UnsupportedOperationException ignored) {

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -389,7 +389,7 @@ public class ProjectScanner {
         }
         if (member instanceof VariableTree variable) {
             try {
-                if (variable.getModifiers().getFlags().contains(Modifier.ENUM)) {
+                if (variable.getType() == null) {
                     return true;
                 }
             } catch (UnsupportedOperationException ignored) {

--- a/src/test/java/com/example/tests/generator/scanner/ProjectScannerTest.java
+++ b/src/test/java/com/example/tests/generator/scanner/ProjectScannerTest.java
@@ -1,14 +1,17 @@
 package com.example.tests.generator.scanner;
 
+import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.project.ProjectLayout;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,5 +48,31 @@ class ProjectScannerTest {
                 .anyMatch(metadata -> "com.example.test.LegacyService".equals(metadata.getQualifiedName())));
         assertFalse(classes.stream()
                 .anyMatch(metadata -> "com.example.test.LegacyServiceTest".equals(metadata.getQualifiedName())));
+    }
+
+    @Test
+    void capturesEnumConstants() throws IOException {
+        Path enumDir = tempDir.resolve("src/main/java/demo");
+        Files.createDirectories(enumDir);
+        Files.writeString(enumDir.resolve("Sample.java"), String.join(System.lineSeparator(),
+                "package demo;",
+                "",
+                "public enum Sample {",
+                "    FIRST,",
+                "    SECOND",
+                "}",
+                ""));
+
+        ProjectLayout layout = new ProjectLayout("src/main/java", "src/test/java");
+        ProjectScanner scanner = new ProjectScanner(tempDir, layout);
+
+        List<ClassMetadata> metadata = scanner.scan();
+        ClassMetadata sample = metadata.stream()
+                .filter(candidate -> candidate.getQualifiedName().equals("demo.Sample"))
+                .findFirst()
+                .orElseThrow();
+
+        assertTrue(sample.isEnumType());
+        assertEquals(List.of("FIRST", "SECOND"), sample.getEnumConstants());
     }
 }

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
@@ -51,7 +51,7 @@ public final class TestFixIterationCoordinator {
         }
 
         for (TestFailureDetail failure : failures) {
-            TestContextSnapshot context = contexts.get(failure.getTestClass());
+            TestContextSnapshot context = resolveContext(contexts, failure);
             if (context == null) {
                 continue;
             }
@@ -63,6 +63,36 @@ public final class TestFixIterationCoordinator {
                         .ifPresent(code -> applySafe(context, code));
             }
         }
+    }
+
+    private TestContextSnapshot resolveContext(Map<String, TestContextSnapshot> contexts, TestFailureDetail failure) {
+        String testClass = failure.getTestClass();
+        TestContextSnapshot context = contexts.get(testClass);
+        if (context != null) {
+            return context;
+        }
+
+        String simpleName = simpleName(testClass);
+        TestContextSnapshot match = null;
+        for (Map.Entry<String, TestContextSnapshot> entry : contexts.entrySet()) {
+            if (simpleName(entry.getKey()).equals(simpleName)) {
+                if (match != null) {
+                    return null;
+                }
+                match = entry.getValue();
+            }
+        }
+
+        if (match != null) {
+            return match;
+        }
+
+        return contexts.get(simpleName);
+    }
+
+    private static String simpleName(String className) {
+        int lastDot = className.lastIndexOf('.');
+        return lastDot >= 0 ? className.substring(lastDot + 1) : className;
     }
 
     private void applySafe(TestContextSnapshot context, String code) {

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
@@ -110,13 +110,25 @@ public final class GradleTestFailureParser {
         String normalized = sourcePath.replace('\\', '/');
         int javaRoot = normalized.indexOf("/src/");
         if (javaRoot >= 0) {
-            int start = normalized.indexOf('/', javaRoot + 5);
-            if (start >= 0 && start + 1 < normalized.length()) {
-                String relative = normalized.substring(start + 1);
-                if (relative.endsWith(".java")) {
-                    relative = relative.substring(0, relative.length() - 5);
+            int javaDir = normalized.indexOf("/java/", javaRoot);
+            if (javaDir >= 0) {
+                int start = javaDir + 6;
+                if (start < normalized.length()) {
+                    String relative = normalized.substring(start);
+                    if (relative.endsWith(".java")) {
+                        relative = relative.substring(0, relative.length() - 5);
+                    }
+                    return relative.replace('/', '.');
                 }
-                return relative.replace('/', '.');
+            } else {
+                int start = normalized.indexOf('/', javaRoot + 5);
+                if (start >= 0 && start + 1 < normalized.length()) {
+                    String relative = normalized.substring(start + 1);
+                    if (relative.endsWith(".java")) {
+                        relative = relative.substring(0, relative.length() - 5);
+                    }
+                    return relative.replace('/', '.');
+                }
             }
         }
 

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/reporting/GradleTestFailureParser.java
@@ -12,6 +12,7 @@ public final class GradleTestFailureParser {
 
     private static final Pattern SUMMARY_LINE = Pattern.compile("^(\\S+) > (.+) FAILED$");
     private static final Pattern ANSI_ESCAPE = Pattern.compile("\u001B\\[[;\\d]*[@-~]");
+    private static final Pattern COMPILATION_ERROR_LINE = Pattern.compile("^(.+?\\.java):(\\d+): error: (.+)$");
 
     public List<TestFailureDetail> parse(String output) {
         List<TestFailureDetail> failures = new ArrayList<>();
@@ -29,6 +30,11 @@ public final class GradleTestFailureParser {
             }
             Matcher matcher = SUMMARY_LINE.matcher(trimmed);
             if (!matcher.matches()) {
+                Matcher compilationMatcher = COMPILATION_ERROR_LINE.matcher(trimmed);
+                if (compilationMatcher.matches()) {
+                    failures.add(parseCompilationError(lines, i, compilationMatcher));
+                    i = advancePastCompilationError(lines, i + 1);
+                }
                 continue;
             }
             String testClass = matcher.group(1);
@@ -62,5 +68,63 @@ public final class GradleTestFailureParser {
 
     private static String stripAnsi(String value) {
         return ANSI_ESCAPE.matcher(value).replaceAll("");
+    }
+
+    private TestFailureDetail parseCompilationError(String[] lines, int index, Matcher matcher) {
+        String sourcePath = matcher.group(1);
+        String message = matcher.group(3).trim();
+        List<String> diagnostics = new ArrayList<>();
+        diagnostics.add(lines[index]);
+
+        int j = index + 1;
+        while (j < lines.length) {
+            String followUp = lines[j];
+            String followUpTrimmed = followUp.stripLeading();
+            if (SUMMARY_LINE.matcher(followUpTrimmed).matches()
+                    || followUpTrimmed.startsWith("> Task")
+                    || COMPILATION_ERROR_LINE.matcher(followUpTrimmed).matches()) {
+                break;
+            }
+            diagnostics.add(followUp);
+            j++;
+        }
+
+        return new TestFailureDetail(resolveClassName(sourcePath), "compileTestJava", message, diagnostics);
+    }
+
+    private int advancePastCompilationError(String[] lines, int index) {
+        int i = index;
+        while (i < lines.length) {
+            String trimmed = lines[i].stripLeading();
+            if (SUMMARY_LINE.matcher(trimmed).matches()
+                    || trimmed.startsWith("> Task")
+                    || COMPILATION_ERROR_LINE.matcher(trimmed).matches()) {
+                break;
+            }
+            i++;
+        }
+        return i - 1;
+    }
+
+    private String resolveClassName(String sourcePath) {
+        String normalized = sourcePath.replace('\\', '/');
+        int javaRoot = normalized.indexOf("/src/");
+        if (javaRoot >= 0) {
+            int start = normalized.indexOf('/', javaRoot + 5);
+            if (start >= 0 && start + 1 < normalized.length()) {
+                String relative = normalized.substring(start + 1);
+                if (relative.endsWith(".java")) {
+                    relative = relative.substring(0, relative.length() - 5);
+                }
+                return relative.replace('/', '.');
+            }
+        }
+
+        int lastSlash = normalized.lastIndexOf('/');
+        String fileName = lastSlash >= 0 ? normalized.substring(lastSlash + 1) : normalized;
+        if (fileName.endsWith(".java")) {
+            fileName = fileName.substring(0, fileName.length() - 5);
+        }
+        return fileName;
     }
 }

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/TestFixIterationCoordinatorTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/TestFixIterationCoordinatorTest.java
@@ -1,0 +1,88 @@
+package com.example.tests.orchestration;
+
+import com.example.tests.orchestration.execution.TestRunRequest;
+import com.example.tests.orchestration.execution.TestRunResult;
+import com.example.tests.orchestration.fix.GigachatResponseParser;
+import com.example.tests.orchestration.fix.TestFixApplier;
+import com.example.tests.orchestration.gigachat.GigachatFixGateway;
+import com.example.tests.orchestration.gigachat.GigachatFixRequestBuilder;
+import com.example.tests.orchestration.gigachat.PromptClient;
+import com.example.tests.orchestration.gigachat.TestContextSnapshot;
+import com.example.tests.orchestration.reporting.TestFailureCollector;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestFixIterationCoordinatorTest {
+
+    @Test
+    void resolvesContextBySimpleClassNameWhenFullyQualifiedEntryExists() throws Exception {
+        RecordingPromptClient promptClient = new RecordingPromptClient();
+        GigachatFixGateway gateway = new GigachatFixGateway(promptClient, new GigachatFixRequestBuilder());
+
+        TestFixIterationCoordinator coordinator = new TestFixIterationCoordinator(
+                request -> new TestRunResult(1, false, Duration.ZERO, failingOutput()),
+                new TestFailureCollector(),
+                gateway,
+                new TestFixApplier(),
+                new GigachatResponseParser());
+
+        Path tempSource = Files.createTempFile("OrderTest", ".java");
+        tempSource.toFile().deleteOnExit();
+        Map<String, TestContextSnapshot> contexts = new HashMap<>();
+        contexts.put("com.acme.discount.OrderTest", new TestContextSnapshot(
+                "com.acme.discount.OrderTest",
+                tempSource,
+                "public class OrderTest {}",
+                Map.of(),
+                Map.of()));
+
+        coordinator.executeAndAttemptFix(
+                TestRunRequest.builder(Path.of(".")).build(),
+                contexts);
+
+        assertEquals(1, promptClient.prompts.size());
+        assertEquals("public class OrderTest {}", promptClient.prompts.get(0).includedSource);
+    }
+
+    private static String failingOutput() {
+        return String.join("\n",
+                "OrderTest > failingTest FAILED",
+                "    java.lang.AssertionError: boom");
+    }
+
+    private static final class RecordingPromptClient implements PromptClient {
+        private final List<RecordedPrompt> prompts = new ArrayList<>();
+
+        @Override
+        public String sendPrompt(String prompt, Map<String, Object> options) {
+            prompts.add(new RecordedPrompt(prompt));
+            return "no code";
+        }
+    }
+
+    private static final class RecordedPrompt {
+        private final String includedSource;
+
+        private RecordedPrompt(String prompt) {
+            int start = prompt.indexOf("```java\n");
+            if (start >= 0) {
+                int end = prompt.indexOf("```", start + 1);
+                if (end > start) {
+                    includedSource = prompt.substring(start + "```java\n".length(), end).strip();
+                    return;
+                }
+            }
+            includedSource = "";
+        }
+    }
+}

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/reporting/GradleTestFailureParserTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/reporting/GradleTestFailureParserTest.java
@@ -53,4 +53,41 @@ class GradleTestFailureParserTest {
         assertEquals("BulkOrderDiscountRuleTest", failures.get(0).getTestClass());
         assertEquals("CustomerProfileTest", failures.get(1).getTestClass());
     }
+
+    @Test
+    void extractsCompilationErrorsWhenTestsDoNotRun() {
+        String output = String.join("\n",
+                "> Task :compileJava UP-TO-DATE",
+                "> Task :processResources NO-SOURCE",
+                "> Task :classes UP-TO-DATE",
+                "",
+                "> Task :compileTestJava FAILED",
+                "/Users/acme/project/examples/discount-service/src/test/java/com/acme/discount/OrderTest.java:30: error: cannot find symbol",
+                "        OrderLine line1 = createOrderLine(\"SKU001\", ProductCategory.FOOD, 3, 10.0);",
+                "                                                                   ^",
+                "  symbol:   variable FOOD",
+                "  location: class ProductCategory",
+                "/Users/acme/project/examples/discount-service/src/test/java/com/acme/discount/OrderTest.java:64: error: cannot find symbol",
+                "        double foodSubtotal = order.getSubtotalForCategory(ProductCategory.FOOD);",
+                "                                                                          ^",
+                "  symbol:   variable FOOD",
+                "  location: class ProductCategory",
+                "",
+                "FAILURE: Build failed with an exception.");
+
+        GradleTestFailureParser parser = new GradleTestFailureParser();
+        List<TestFailureDetail> failures = parser.parse(output);
+
+        assertEquals(2, failures.size());
+
+        TestFailureDetail first = failures.get(0);
+        assertEquals("com.acme.discount.OrderTest", first.getTestClass());
+        assertEquals("compileTestJava", first.getTestMethod());
+        assertEquals("cannot find symbol", first.getMessage());
+        assertEquals(5, first.getDiagnostics().size());
+
+        TestFailureDetail second = failures.get(1);
+        assertEquals("com.acme.discount.OrderTest", second.getTestClass());
+        assertEquals("cannot find symbol", second.getMessage());
+    }
 }


### PR DESCRIPTION
## Summary
- extend the Gradle test failure parser to detect Java compilation errors and convert them into failure details
- derive class names from source paths for compilation errors and collect related diagnostics
- cover the new parsing behavior with a unit test exercising Gradle compiler output

## Testing
- gradle :test-orchestration:test --tests "*GradleTestFailureParserTest" *(fails: dependency download blocked by 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d188f91883209ea1997f9e355269