### PR TITLE
Introduce extensible verifier for generated tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation platform('org.junit:junit-bom:5.10.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -16,6 +16,7 @@ import com.example.tests.generator.scanner.ProjectScanner;
 import com.example.tests.generator.validate.ResponseValidator;
 import com.example.tests.generator.validate.TestCodeParser;
 import com.example.tests.generator.validate.ValidationResult;
+import com.example.tests.generator.verification.GeneratedTestVerifier;
 import com.example.tests.generator.config.GigachatClientConfig;
 import com.example.tests.generator.config.GigachatClientProperties;
 import com.example.tests.generator.util.LoggingConfigurator;
@@ -75,6 +76,7 @@ public final class TestGeneratorCli {
         ResponseValidator responseValidator = new ResponseValidator();
         TestCodeParser codeParser = new TestCodeParser();
         TestGenerationPipeline pipeline = new TestGenerationPipeline(projectRoot, projectLayout);
+        GeneratedTestVerifier testVerifier = new GeneratedTestVerifier();
 
         boolean infoLogging = arguments.infoLogging();
 
@@ -136,7 +138,9 @@ public final class TestGeneratorCli {
                 }
 
                 if (parsedClass.isPresent()) {
-                    lastGeneratedClass = parsedClass.get();
+                    GeneratedTestClass generatedTestClass = testVerifier.verify(parsedClass.get(), promptMetadata);
+                    parsedClass = Optional.of(generatedTestClass);
+                    lastGeneratedClass = generatedTestClass;
                 }
 
                 if (!validationResult.isValid()) {
@@ -147,22 +151,40 @@ public final class TestGeneratorCli {
                     GeneratedTestClass generatedTestClass = parsedClass.get();
                     try {
                         TestGenerationPipeline.TestCompilationResult compilationResult = pipeline.verifyCompilation(generatedTestClass);
-                        if (compilationResult.successful()) {
-                            if (validationResult.isValid()) {
-                                generatedClasses.add(generatedTestClass);
-                                metadataByTestClass.put(generatedTestClass.getFullyQualifiedName(), promptMetadata);
-                                success = true;
-                                break;
+                        if (!compilationResult.successful()) {
+                            List<String> compileErrors = new ArrayList<>(compilationResult.errors().isEmpty()
+                                    ? List.of("Compilation failed but produced no diagnostics.")
+                                    : compilationResult.errors());
+                            compileErrors.forEach(error -> LOGGER.severe(() -> "Ошибка компиляции: " + error));
+                            GeneratedTestClass fixedAfterCompile = testVerifier.verify(generatedTestClass, promptMetadata, compileErrors);
+                            if (!fixedAfterCompile.getSourceCode().equals(generatedTestClass.getSourceCode())) {
+                                GeneratedTestClass finalFixedAfterCompile = fixedAfterCompile;
+                                LOGGER.info(() -> "Применение автоматических правок после ошибки компиляции");
+                                TestGenerationPipeline.TestCompilationResult retryResult = pipeline.verifyCompilation(fixedAfterCompile);
+                                if (retryResult.successful()) {
+                                    compilationResult = retryResult;
+                                    generatedTestClass = finalFixedAfterCompile;
+                                    parsedClass = Optional.of(generatedTestClass);
+                                    lastGeneratedClass = generatedTestClass;
+                                    compileErrors.clear();
+                                } else {
+                                    List<String> retryErrors = retryResult.errors().isEmpty()
+                                            ? List.of("Compilation retry failed without diagnostics.")
+                                            : retryResult.errors();
+                                    retryErrors.forEach(error -> LOGGER.severe(() -> "Ошибка компиляции (повтор): " + error));
+                                    compileErrors.addAll(retryErrors);
+                                }
                             }
-                        } else {
-                            if (compilationResult.errors().isEmpty()) {
-                                attemptIssues.add("Compilation failed but produced no diagnostics.");
-                            } else {
-                                compilationResult.errors().forEach(error -> {
-                                    LOGGER.severe(() -> "Ошибка компиляции: " + error);
-                                    attemptIssues.add(error);
-                                });
+                            if (!compileErrors.isEmpty()) {
+                                attemptIssues.addAll(compileErrors);
                             }
+                        }
+
+                        if (compilationResult.successful() && validationResult.isValid()) {
+                            generatedClasses.add(generatedTestClass);
+                            metadataByTestClass.put(generatedTestClass.getFullyQualifiedName(), promptMetadata);
+                            success = true;
+                            break;
                         }
                     } catch (IOException ioException) {
                         String errorMessage = "Failed to persist generated test: " + ioException.getMessage();

--- a/src/main/java/com/example/tests/generator/verification/GeneratedTestContext.java
+++ b/src/main/java/com/example/tests/generator/verification/GeneratedTestContext.java
@@ -1,0 +1,55 @@
+package com.example.tests.generator.verification;
+
+import com.example.tests.generator.metadata.ClassMetadata;
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Shared mutable context used by {@link GeneratedTestRule} implementations when
+ * applying automated fixes to a generated test class.
+ */
+public final class GeneratedTestContext {
+
+    private final GeneratedTestClass original;
+    private final ClassMetadata metadata;
+    private final List<String> compilationErrors;
+    private String sourceCode;
+
+    public GeneratedTestContext(GeneratedTestClass original,
+                                ClassMetadata metadata,
+                                List<String> compilationErrors) {
+        this.original = Objects.requireNonNull(original, "original");
+        this.metadata = metadata;
+        this.sourceCode = original.getSourceCode();
+        if (compilationErrors == null || compilationErrors.isEmpty()) {
+            this.compilationErrors = List.of();
+        } else {
+            this.compilationErrors = Collections.unmodifiableList(new ArrayList<>(compilationErrors));
+        }
+    }
+
+    public GeneratedTestClass getOriginal() {
+        return original;
+    }
+
+    public Optional<ClassMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
+    }
+
+    public List<String> getCompilationErrors() {
+        return compilationErrors;
+    }
+
+    public String getSourceCode() {
+        return sourceCode;
+    }
+
+    public void setSourceCode(String sourceCode) {
+        this.sourceCode = Objects.requireNonNull(sourceCode, "sourceCode");
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/GeneratedTestRule.java
+++ b/src/main/java/com/example/tests/generator/verification/GeneratedTestRule.java
@@ -1,0 +1,11 @@
+package com.example.tests.generator.verification;
+
+/**
+ * Represents a single rule that can mutate a generated test class to satisfy
+ * local coding conventions or compilation requirements.
+ */
+@FunctionalInterface
+public interface GeneratedTestRule {
+
+    void apply(GeneratedTestContext context);
+}

--- a/src/main/java/com/example/tests/generator/verification/GeneratedTestVerifier.java
+++ b/src/main/java/com/example/tests/generator/verification/GeneratedTestVerifier.java
@@ -1,0 +1,62 @@
+package com.example.tests.generator.verification;
+
+import com.example.tests.generator.metadata.ClassMetadata;
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.verification.rules.DependencyFieldCleanupRule;
+import com.example.tests.generator.verification.rules.ImportSanitizerRule;
+import com.example.tests.generator.verification.rules.MethodSignatureNormalizationRule;
+import com.example.tests.generator.verification.rules.MockitoCompilationFixRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Applies a sequence of {@link GeneratedTestRule rules} to a generated test
+ * class. The verifier is intentionally simple so that new rules can be added in
+ * the future without touching existing call sites.
+ */
+public final class GeneratedTestVerifier {
+
+    private final List<GeneratedTestRule> rules;
+
+    public GeneratedTestVerifier() {
+        this(List.of(
+                new MockitoCompilationFixRule(),
+                new ImportSanitizerRule(),
+                new MethodSignatureNormalizationRule(),
+                new DependencyFieldCleanupRule()
+        ));
+    }
+
+    public GeneratedTestVerifier(List<GeneratedTestRule> rules) {
+        Objects.requireNonNull(rules, "rules");
+        if (rules.isEmpty()) {
+            throw new IllegalArgumentException("rules must not be empty");
+        }
+        this.rules = List.copyOf(rules);
+    }
+
+    public GeneratedTestClass verify(GeneratedTestClass generatedTest, ClassMetadata metadata) {
+        return verify(generatedTest, metadata, List.of());
+    }
+
+    public GeneratedTestClass verify(GeneratedTestClass generatedTest,
+                                     ClassMetadata metadata,
+                                     List<String> compilationErrors) {
+        Objects.requireNonNull(generatedTest, "generatedTest");
+        GeneratedTestContext context = new GeneratedTestContext(generatedTest, metadata, compilationErrors);
+        for (GeneratedTestRule rule : rules) {
+            rule.apply(context);
+        }
+        return new GeneratedTestClass(
+                generatedTest.getPackageName(),
+                generatedTest.getClassName(),
+                context.getSourceCode()
+        );
+    }
+
+    public List<GeneratedTestRule> getRules() {
+        return new ArrayList<>(rules);
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRule.java
@@ -21,12 +21,15 @@ public final class DependencyFieldCleanupRule implements GeneratedTestRule {
         Objects.requireNonNull(context, "context");
         String source = context.getSourceCode();
         boolean modified;
+        boolean hasInjectMocks = containsInjectMocks(source);
         do {
             modified = false;
             Matcher matcher = MOCK_FIELD_PATTERN.matcher(source);
             while (matcher.find()) {
                 String fieldName = matcher.group(2);
-                if (!isFieldUsed(source, fieldName, matcher.start(), matcher.end())) {
+                if (!isFieldUsed(source, fieldName, matcher.start(), matcher.end())
+                        && !isReferencedInAnnotations(source, fieldName)
+                        && !participatesInInjection(matcher.group(1), hasInjectMocks)) {
                     int removalStart = adjustRemovalStart(source, matcher.start());
                     int removalEnd = adjustRemovalEnd(source, matcher.end());
                     source = source.substring(0, removalStart) + source.substring(removalEnd);
@@ -37,6 +40,22 @@ public final class DependencyFieldCleanupRule implements GeneratedTestRule {
             }
         } while (modified);
         context.setSourceCode(source);
+    }
+
+    private boolean containsInjectMocks(String source) {
+        return Pattern.compile("@InjectMocks").matcher(source).find();
+    }
+
+    private boolean isReferencedInAnnotations(String source, String fieldName) {
+        Pattern annotationUsagePattern = Pattern.compile("@\\w+\\([^)]*\\b" + Pattern.quote(fieldName) + "\\b[^)]*\\)");
+        return annotationUsagePattern.matcher(source).find();
+    }
+
+    private boolean participatesInInjection(String fieldBlock, boolean hasInjectMocks) {
+        if (!hasInjectMocks) {
+            return false;
+        }
+        return fieldBlock.contains("@Mock") || fieldBlock.contains("@Spy");
     }
 
     private boolean isFieldUsed(String source, String fieldName, int declarationStart, int declarationEnd) {

--- a/src/main/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRule.java
@@ -1,0 +1,86 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.verification.GeneratedTestContext;
+import com.example.tests.generator.verification.GeneratedTestRule;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Removes Mockito injected fields that are declared but never used inside the
+ * generated test class.
+ */
+public final class DependencyFieldCleanupRule implements GeneratedTestRule {
+
+    private static final Pattern MOCK_FIELD_PATTERN = Pattern.compile(
+            "(?ms)(\s*@(?:Mock|Spy|Captor)\\s*(?:@\\w+[^\\r\\n]*\\s*)*(?:private|protected|public)\\s+[\\w<>\\[\\],\\s]+?\\s+(\\w+)\\s*;\\s*)");
+
+    @Override
+    public void apply(GeneratedTestContext context) {
+        Objects.requireNonNull(context, "context");
+        String source = context.getSourceCode();
+        boolean modified;
+        do {
+            modified = false;
+            Matcher matcher = MOCK_FIELD_PATTERN.matcher(source);
+            while (matcher.find()) {
+                String fieldName = matcher.group(2);
+                if (!isFieldUsed(source, fieldName, matcher.start(), matcher.end())) {
+                    int removalStart = adjustRemovalStart(source, matcher.start());
+                    int removalEnd = adjustRemovalEnd(source, matcher.end());
+                    source = source.substring(0, removalStart) + source.substring(removalEnd);
+                    source = collapseBlankLines(source);
+                    modified = true;
+                    break;
+                }
+            }
+        } while (modified);
+        context.setSourceCode(source);
+    }
+
+    private boolean isFieldUsed(String source, String fieldName, int declarationStart, int declarationEnd) {
+        Pattern usagePattern = Pattern.compile("\\b" + Pattern.quote(fieldName) + "\\b");
+        Matcher usageMatcher = usagePattern.matcher(source);
+        while (usageMatcher.find()) {
+            int start = usageMatcher.start();
+            if (start >= declarationStart && start < declarationEnd) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private int adjustRemovalStart(String source, int start) {
+        int removalStart = start;
+        while (removalStart > 0 && source.charAt(removalStart - 1) == ' ') {
+            removalStart--;
+        }
+        if (removalStart > 0 && (source.charAt(removalStart - 1) == '\n' || source.charAt(removalStart - 1) == '\r')) {
+            removalStart--;
+            if (removalStart > 0 && source.charAt(removalStart - 1) == '\r') {
+                removalStart--;
+            }
+        }
+        return removalStart;
+    }
+
+    private int adjustRemovalEnd(String source, int end) {
+        int removalEnd = end;
+        while (removalEnd < source.length() && (source.charAt(removalEnd) == '\t' || source.charAt(removalEnd) == ' ')) {
+            removalEnd++;
+        }
+        if (removalEnd < source.length() && (source.charAt(removalEnd) == '\n' || source.charAt(removalEnd) == '\r')) {
+            removalEnd++;
+            if (removalEnd < source.length() && source.charAt(removalEnd) == '\n') {
+                removalEnd++;
+            }
+        }
+        return removalEnd;
+    }
+
+    private String collapseBlankLines(String source) {
+        return source.replaceAll("(?m)\n{3,}", "\n\n");
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/rules/ImportSanitizerRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/ImportSanitizerRule.java
@@ -1,0 +1,166 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.verification.GeneratedTestContext;
+import com.example.tests.generator.verification.GeneratedTestRule;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Ensures that required JUnit and Mockito imports are present and removes simple
+ * duplicates while keeping the original import order.
+ */
+public final class ImportSanitizerRule implements GeneratedTestRule {
+
+    private static final Pattern IMPORT_PATTERN = Pattern.compile(
+            "(?m)^\\s*import\\s+(static\\s+)?([\\w\\.]+(?:\\.\\*)?)\\s*;\\s*$");
+
+    @Override
+    public void apply(GeneratedTestContext context) {
+        Objects.requireNonNull(context, "context");
+        String source = context.getSourceCode();
+        Matcher matcher = IMPORT_PATTERN.matcher(source);
+        Set<String> orderedImports = new LinkedHashSet<>();
+        int firstImportStart = -1;
+        int lastImportEnd = -1;
+        while (matcher.find()) {
+            if (firstImportStart == -1) {
+                firstImportStart = matcher.start();
+            }
+            lastImportEnd = matcher.end();
+            String prefix = matcher.group(1) == null ? "" : "static ";
+            orderedImports.add(prefix + matcher.group(2));
+        }
+
+        Set<String> requiredImports = collectRequiredImports(source);
+        requiredImports.stream()
+                .filter(required -> orderedImports.stream().noneMatch(existing -> existing.equals(required)))
+                .forEach(orderedImports::add);
+
+        if (firstImportStart == -1) {
+            if (orderedImports.isEmpty()) {
+                return;
+            }
+            String importBlock = orderedImports.stream()
+                    .filter(entry -> !entry.startsWith("static "))
+                    .map(entry -> "import " + entry + ";\n")
+                    .collect(Collectors.joining());
+            String staticBlock = orderedImports.stream()
+                    .filter(entry -> entry.startsWith("static "))
+                    .map(entry -> "import " + entry + ";\n")
+                    .collect(Collectors.joining());
+            String block = importBlock + staticBlock;
+            int packageEnd = locatePackageStatementEnd(source);
+            StringBuilder builder = new StringBuilder();
+            builder.append(source, 0, packageEnd);
+            if (packageEnd > 0 && source.charAt(packageEnd - 1) != '\n') {
+                builder.append('\n');
+            }
+            builder.append(block);
+            if (!block.isEmpty() && (packageEnd >= source.length() || source.charAt(packageEnd) != '\n')) {
+                builder.append('\n');
+            }
+            builder.append(source.substring(packageEnd));
+            context.setSourceCode(builder.toString());
+            return;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(source, 0, firstImportStart);
+        String normalBlock = orderedImports.stream()
+                .filter(entry -> !entry.startsWith("static "))
+                .map(entry -> "import " + entry + ";\n")
+                .collect(Collectors.joining());
+        String staticBlock = orderedImports.stream()
+                .filter(entry -> entry.startsWith("static "))
+                .map(entry -> "import " + entry + ";\n")
+                .collect(Collectors.joining());
+        builder.append(normalBlock).append(staticBlock);
+        if (!normalBlock.isEmpty() || !staticBlock.isEmpty()) {
+            builder.append('\n');
+        }
+        builder.append(source.substring(lastImportEnd));
+        context.setSourceCode(builder.toString());
+    }
+
+    private Set<String> collectRequiredImports(String source) {
+        Set<String> required = new LinkedHashSet<>();
+        if (source.contains("@Test")) {
+            required.add("org.junit.jupiter.api.Test");
+        }
+        if (source.contains("@BeforeEach")) {
+            required.add("org.junit.jupiter.api.BeforeEach");
+        }
+        if (source.contains("@BeforeAll")) {
+            required.add("org.junit.jupiter.api.BeforeAll");
+        }
+        if (source.contains("@AfterEach")) {
+            required.add("org.junit.jupiter.api.AfterEach");
+        }
+        if (source.contains("@AfterAll")) {
+            required.add("org.junit.jupiter.api.AfterAll");
+        }
+        if (source.contains("@ParameterizedTest")) {
+            required.add("org.junit.jupiter.params.ParameterizedTest");
+        }
+        if (source.contains("@CsvSource")) {
+            required.add("org.junit.jupiter.params.provider.CsvSource");
+        }
+        if (source.contains("@MethodSource")) {
+            required.add("org.junit.jupiter.params.provider.MethodSource");
+        }
+        if (source.contains("@ExtendWith")) {
+            required.add("org.junit.jupiter.api.extension.ExtendWith");
+        }
+        if (source.contains("Assertions.")) {
+            required.add("org.junit.jupiter.api.Assertions");
+        }
+        if (source.contains("Assumptions.")) {
+            required.add("org.junit.jupiter.api.Assumptions");
+        }
+        if (source.contains("MockitoExtension")) {
+            required.add("org.mockito.junit.jupiter.MockitoExtension");
+        }
+        if (source.contains("ArgumentCaptor")) {
+            required.add("org.mockito.ArgumentCaptor");
+        }
+        if (source.contains("Mockito.")) {
+            required.add("org.mockito.Mockito");
+        }
+        if (source.contains("ArgumentMatchers.")) {
+            required.add("org.mockito.ArgumentMatchers");
+        }
+        if (source.contains("BDDMockito.")) {
+            required.add("org.mockito.BDDMockito");
+        }
+        if (source.contains("@Mock")) {
+            required.add("org.mockito.Mock");
+        }
+        if (source.contains("@Spy")) {
+            required.add("org.mockito.Spy");
+        }
+        if (source.contains("@Captor")) {
+            required.add("org.mockito.Captor");
+        }
+        if (source.contains("@InjectMocks")) {
+            required.add("org.mockito.InjectMocks");
+        }
+        return required;
+    }
+
+    private int locatePackageStatementEnd(String source) {
+        Matcher matcher = Pattern.compile("(?m)^\\s*package\\s+[\\w\\.]+\\s*;\\s*$").matcher(source);
+        if (matcher.find()) {
+            int end = matcher.end();
+            while (end < source.length() && (source.charAt(end) == '\r' || source.charAt(end) == '\n')) {
+                end++;
+            }
+            return end;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRule.java
@@ -1,0 +1,78 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.verification.GeneratedTestContext;
+import com.example.tests.generator.verification.GeneratedTestRule;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Normalises signatures of generated JUnit test methods to the conventional
+ * {@code public void methodName()} form.
+ */
+public final class MethodSignatureNormalizationRule implements GeneratedTestRule {
+
+    private static final Pattern TEST_METHOD_PATTERN = Pattern.compile(
+            "(@Test(?:\\s*\\R\\s*@\\w+[^\\r\\n]*)*\\s*)(public\\s+)([\\w<>\\[\\],\\s]+?)\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*\\{",
+            Pattern.MULTILINE);
+
+    @Override
+    public void apply(GeneratedTestContext context) {
+        Objects.requireNonNull(context, "context");
+        String source = context.getSourceCode();
+        Matcher matcher = TEST_METHOD_PATTERN.matcher(source);
+        StringBuffer buffer = new StringBuffer();
+        boolean modified = false;
+        while (matcher.find()) {
+            String originalReturn = matcher.group(3).trim();
+            String originalParameters = matcher.group(5);
+            boolean hasParameters = originalParameters != null && !originalParameters.trim().isEmpty();
+            boolean shouldNormalizeReturn = !"void".equals(originalReturn)
+                    && !containsValueReturn(source, matcher.end());
+            boolean shouldRemoveParameters = hasParameters;
+            if (shouldNormalizeReturn || shouldRemoveParameters) {
+                String newReturn = shouldNormalizeReturn ? "void" : originalReturn;
+                String parameterSection = shouldRemoveParameters ? "" : originalParameters.trim();
+                String replacement = matcher.group(1)
+                        + matcher.group(2)
+                        + newReturn
+                        + " "
+                        + matcher.group(4)
+                        + "(" + parameterSection + ")";
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement + " {"));
+                modified = true;
+            }
+        }
+        if (modified) {
+            matcher.appendTail(buffer);
+            context.setSourceCode(buffer.toString());
+        }
+    }
+
+    private boolean containsValueReturn(String source, int bodyStart) {
+        int depth = 1;
+        for (int i = bodyStart; i < source.length() && depth > 0; i++) {
+            char current = source.charAt(i);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+                continue;
+            }
+            if (depth > 0 && current == 'r' && source.startsWith("return", i)) {
+                int after = i + "return".length();
+                if (after >= source.length()) {
+                    continue;
+                }
+                while (after < source.length() && Character.isWhitespace(source.charAt(after))) {
+                    after++;
+                }
+                if (after < source.length() && source.charAt(after) != ';') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/rules/MockitoCompilationFixRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/MockitoCompilationFixRule.java
@@ -1,0 +1,160 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.verification.GeneratedTestContext;
+import com.example.tests.generator.verification.GeneratedTestRule;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Attempts to fix the most common Mockito related compilation issues by adding
+ * the required JUnit extension annotation and missing imports.
+ */
+public final class MockitoCompilationFixRule implements GeneratedTestRule {
+
+    private static final Pattern CLASS_DECLARATION = Pattern.compile(
+            "(?m)^(?:public|protected|private)?\\s*(?:final\\s+)?class\\s+\\w+[^\\{]*\\{");
+
+    @Override
+    public void apply(GeneratedTestContext context) {
+        Objects.requireNonNull(context, "context");
+        String source = context.getSourceCode();
+        boolean usesMock = containsAny(source, "@Mock");
+        boolean usesSpy = containsAny(source, "@Spy");
+        boolean usesCaptor = containsAny(source, "@Captor");
+        boolean usesInjectMocks = containsAny(source, "@InjectMocks");
+        boolean usesMockito = containsAny(source, "Mockito.");
+        boolean usesArgumentCaptor = containsAny(source, "ArgumentCaptor");
+        boolean usesArgumentMatchers = containsAny(source, "ArgumentMatchers.");
+        boolean usesBddMockito = containsAny(source, "BDDMockito.");
+        boolean alreadyExtendWith = containsAny(source, "@ExtendWith(");
+        boolean mentionsMockitoExtension = containsAny(source, "MockitoExtension");
+
+        Set<String> importsToEnsure = new LinkedHashSet<>();
+        if (usesMock) {
+            importsToEnsure.add("org.mockito.Mock");
+        }
+        if (usesSpy) {
+            importsToEnsure.add("org.mockito.Spy");
+        }
+        if (usesCaptor) {
+            importsToEnsure.add("org.mockito.Captor");
+        }
+        if (usesInjectMocks) {
+            importsToEnsure.add("org.mockito.InjectMocks");
+        }
+        if (usesMockito) {
+            importsToEnsure.add("org.mockito.Mockito");
+        }
+        if (usesArgumentCaptor) {
+            importsToEnsure.add("org.mockito.ArgumentCaptor");
+        }
+        if (usesArgumentMatchers) {
+            importsToEnsure.add("org.mockito.ArgumentMatchers");
+        }
+        if (usesBddMockito) {
+            importsToEnsure.add("org.mockito.BDDMockito");
+        }
+
+        boolean shouldAddExtension = (usesMock || usesSpy || usesInjectMocks || mentionsMockitoExtension)
+                && !alreadyExtendWith;
+        if (shouldAddExtension) {
+            source = insertExtendWithAnnotation(source);
+            importsToEnsure.add("org.junit.jupiter.api.extension.ExtendWith");
+            importsToEnsure.add("org.mockito.junit.jupiter.MockitoExtension");
+        } else if (alreadyExtendWith && containsAny(source, "MockitoExtension") ) {
+            importsToEnsure.add("org.mockito.junit.jupiter.MockitoExtension");
+        }
+
+        if (!importsToEnsure.isEmpty()) {
+            source = ensureImportsPresent(source, importsToEnsure);
+        }
+
+        context.setSourceCode(source);
+    }
+
+    private boolean containsAny(String source, String needle) {
+        return source.contains(needle);
+    }
+
+    private String insertExtendWithAnnotation(String source) {
+        Matcher matcher = CLASS_DECLARATION.matcher(source);
+        if (!matcher.find()) {
+            return source;
+        }
+        int lineStart = matcher.start();
+        while (lineStart > 0 && source.charAt(lineStart - 1) != '\n' && source.charAt(lineStart - 1) != '\r') {
+            lineStart--;
+        }
+        int indentEnd = lineStart;
+        while (indentEnd < source.length() && (source.charAt(indentEnd) == ' ' || source.charAt(indentEnd) == '\t')) {
+            indentEnd++;
+        }
+        String indent = source.substring(lineStart, indentEnd);
+        StringBuilder builder = new StringBuilder();
+        builder.append(source, 0, lineStart);
+        if (lineStart > 0 && source.charAt(lineStart - 1) != '\n') {
+            builder.append('\n');
+        }
+        builder.append(indent).append("@ExtendWith(MockitoExtension.class)").append('\n');
+        builder.append(source.substring(lineStart));
+        return builder.toString();
+    }
+
+    private String ensureImportsPresent(String source, Set<String> importsToEnsure) {
+        Pattern importPattern = Pattern.compile("(?m)^\\s*import\\s+([\\w\\.]+(?:\\.\\*)?)\\s*;\\s*$");
+        Matcher matcher = importPattern.matcher(source);
+        Set<String> existing = new LinkedHashSet<>();
+        int lastImportEnd = -1;
+        while (matcher.find()) {
+            lastImportEnd = matcher.end();
+            existing.add(matcher.group(1));
+        }
+
+        List<String> missing = importsToEnsure.stream()
+                .filter(importName -> existing.stream().noneMatch(current -> current.equals(importName)))
+                .collect(Collectors.toList());
+        if (missing.isEmpty()) {
+            return source;
+        }
+
+        String importBlock = missing.stream()
+                .map(name -> "import " + name + ";\n")
+                .collect(Collectors.joining());
+
+        StringBuilder builder = new StringBuilder();
+        if (lastImportEnd != -1) {
+            builder.append(source, 0, lastImportEnd);
+            builder.append(importBlock);
+            builder.append(source.substring(lastImportEnd));
+        } else {
+            int packageEnd = locatePackageStatementEnd(source);
+            builder.append(source, 0, packageEnd);
+            if (packageEnd > 0 && source.charAt(packageEnd - 1) != '\n') {
+                builder.append('\n');
+            }
+            builder.append(importBlock);
+            builder.append('\n');
+            builder.append(source.substring(packageEnd));
+        }
+        return builder.toString();
+    }
+
+    private int locatePackageStatementEnd(String source) {
+        Pattern packagePattern = Pattern.compile("(?m)^\\s*package\\s+[\\w\\.]+\\s*;\\s*$");
+        Matcher matcher = packagePattern.matcher(source);
+        if (matcher.find()) {
+            int end = matcher.end();
+            while (end < source.length() && (source.charAt(end) == '\r' || source.charAt(end) == '\n')) {
+                end++;
+            }
+            return end;
+        }
+        return 0;
+    }
+}

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -1,0 +1,51 @@
+package com.example.tests.generator.verification;
+
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneratedTestVerifierTest {
+
+    private final GeneratedTestVerifier verifier = new GeneratedTestVerifier();
+
+    @Test
+    void appliesDefaultRulesToGeneratedClass() {
+        String originalSource = """
+                package com.example;
+
+                import foo.bar.Bar;
+
+                public class SampleServiceTest {
+
+                    @Mock
+                    private Bar unused;
+
+                    @Mock
+                    private Bar used;
+
+                    @Test
+                    public Bar shouldCallService(Bar dependency) {
+                        Mockito.when(used.toString()).thenReturn("value");
+                        String result = used.toString();
+                        Assertions.assertEquals("value", result);
+                    }
+                }
+                """;
+        GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleServiceTest", originalSource);
+
+        GeneratedTestClass verified = verifier.verify(generated, null);
+        String verifiedSource = verified.getSourceCode();
+
+        assertThat(verifiedSource).contains("@ExtendWith(MockitoExtension.class)");
+        assertThat(verifiedSource).contains("import org.junit.jupiter.api.Test;");
+        assertThat(verifiedSource).contains("import org.junit.jupiter.api.Assertions;");
+        assertThat(verifiedSource).contains("import org.mockito.Mock;");
+        assertThat(verifiedSource).contains("import org.mockito.Mockito;");
+        assertThat(verifiedSource).contains("import org.mockito.junit.jupiter.MockitoExtension;");
+        assertThat(verifiedSource).contains("import foo.bar.Bar;");
+        assertThat(verifiedSource).doesNotContain("unused;");
+        assertThat(verifiedSource).contains("void shouldCallService()");
+        assertThat(verifiedSource).doesNotContain("Bar dependency");
+    }
+}

--- a/src/test/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRuleTest.java
+++ b/src/test/java/com/example/tests/generator/verification/rules/DependencyFieldCleanupRuleTest.java
@@ -1,0 +1,80 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.verification.GeneratedTestContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DependencyFieldCleanupRuleTest {
+
+    private final DependencyFieldCleanupRule rule = new DependencyFieldCleanupRule();
+
+    @Test
+    void removesUnusedMockFields() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+                import org.mockito.Mock;
+
+                public class SampleTest {
+
+                    @Mock
+                    private Dependency unused;
+
+                    @Mock
+                    private Dependency used;
+
+                    @Test
+                    void executes() {
+                        used.toString();
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).doesNotContain("unused");
+        assertThat(updated).contains("private Dependency used;");
+    }
+
+    @Test
+    void keepsFieldsReferencedInAnnotationsOrCode() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+                import org.mockito.InjectMocks;
+                import org.mockito.Mock;
+
+                public class SampleTest {
+
+                    @Mock
+                    private Dependency dependency;
+
+                    @InjectMocks
+                    private Service service;
+
+                    @Test
+                    void executes() {
+                        service.run();
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("private Dependency dependency;");
+        assertThat(updated).contains("private Service service;");
+    }
+
+    private GeneratedTestContext contextFor(String source) {
+        GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleTest", source);
+        return new GeneratedTestContext(generated, null, java.util.List.of());
+    }
+}

--- a/src/test/java/com/example/tests/generator/verification/rules/ImportSanitizerRuleTest.java
+++ b/src/test/java/com/example/tests/generator/verification/rules/ImportSanitizerRuleTest.java
@@ -1,0 +1,67 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.verification.GeneratedTestContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImportSanitizerRuleTest {
+
+    private final ImportSanitizerRule rule = new ImportSanitizerRule();
+
+    @Test
+    void addsMissingImportsAndDeduplicatesExistingOnes() {
+        String source = """
+                package com.example;
+
+                import foo.Bar;
+                import foo.Bar;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                public class SampleTest {
+
+                    @Test
+                    void usesAssertions() {
+                        assertEquals(1, 1);
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("import foo.Bar;\n");
+        assertThat(updated).containsOnlyOnce("import org.junit.jupiter.api.Test;");
+        assertThat(updated).containsOnlyOnce("import org.junit.jupiter.api.Assertions;");
+        assertThat(updated).containsOnlyOnce("import static org.junit.jupiter.api.Assertions.assertEquals;");
+    }
+
+    @Test
+    void insertsImportBlockWhenNonePresent() {
+        String source = """
+                package com.example;
+
+                public class SampleTest {
+
+                    @BeforeEach
+                    void setUp() {
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("import org.junit.jupiter.api.BeforeEach;\n");
+        assertThat(updated).contains("package com.example;\n\nimport org.junit.jupiter.api.BeforeEach;\n\npublic class SampleTest");
+    }
+
+    private GeneratedTestContext contextFor(String source) {
+        GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleTest", source);
+        return new GeneratedTestContext(generated, null, java.util.List.of());
+    }
+}

--- a/src/test/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRuleTest.java
+++ b/src/test/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRuleTest.java
@@ -1,0 +1,64 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.verification.GeneratedTestContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MethodSignatureNormalizationRuleTest {
+
+    private final MethodSignatureNormalizationRule rule = new MethodSignatureNormalizationRule();
+
+    @Test
+    void convertsReturnTypeToVoidAndRemovesParameters() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+
+                public class SampleTest {
+
+                    @Test
+                    public String shouldCallService(String dependency) {
+                        dependency.toString();
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("public void shouldCallService()");
+        assertThat(updated).doesNotContain("String dependency");
+    }
+
+    @Test
+    void keepsReturnTypeWhenMethodReturnsValue() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+
+                public class SampleTest {
+
+                    @Test
+                    public String shouldReturnValue() {
+                        return "value";
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("public String shouldReturnValue()");
+    }
+
+    private GeneratedTestContext contextFor(String source) {
+        GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleTest", source);
+        return new GeneratedTestContext(generated, null, java.util.List.of());
+    }
+}

--- a/src/test/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRuleTest.java
+++ b/src/test/java/com/example/tests/generator/verification/rules/MethodSignatureNormalizationRuleTest.java
@@ -1,5 +1,8 @@
 package com.example.tests.generator.verification.rules;
 
+import com.example.tests.generator.metadata.ClassMetadata;
+import com.example.tests.generator.metadata.MethodMetadata;
+import com.example.tests.generator.metadata.ParameterMetadata;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
 import com.example.tests.generator.verification.GeneratedTestContext;
 import org.junit.jupiter.api.Test;
@@ -25,7 +28,11 @@ class MethodSignatureNormalizationRuleTest {
                     }
                 }
                 """;
-        GeneratedTestContext context = contextFor(source);
+        GeneratedTestContext context = contextFor(source, metadata(builder -> builder
+                .addMethod(MethodMetadata.builder()
+                        .name("shouldCallService")
+                        .returnType("void")
+                        .build())));
 
         rule.apply(context);
 
@@ -49,7 +56,11 @@ class MethodSignatureNormalizationRuleTest {
                     }
                 }
                 """;
-        GeneratedTestContext context = contextFor(source);
+        GeneratedTestContext context = contextFor(source, metadata(builder -> builder
+                .addMethod(MethodMetadata.builder()
+                        .name("shouldReturnValue")
+                        .returnType("java.lang.String")
+                        .build())));
 
         rule.apply(context);
 
@@ -57,8 +68,75 @@ class MethodSignatureNormalizationRuleTest {
         assertThat(updated).contains("public String shouldReturnValue()");
     }
 
-    private GeneratedTestContext contextFor(String source) {
+    @Test
+    void stripsSignatureCopiedFromProductionMethod() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+
+                public class SampleTest {
+
+                    @Test
+                    public Response process(Request request) {
+                        subject.process(request);
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source, metadata(builder -> builder
+                .addMethod(MethodMetadata.builder()
+                        .name("process")
+                        .returnType("com.example.Response")
+                        .addParameter(ParameterMetadata.builder()
+                                .name("request")
+                                .type("com.example.Request")
+                                .build())
+                        .build())));
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("public void process()");
+        assertThat(updated).doesNotContain("Request request");
+        assertThat(updated).doesNotContain("Response process");
+    }
+
+    @Test
+    void normalizesReturnTypeForMethodsWithVoidProductionSignature() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+
+                public class SampleTest {
+
+                    @Test
+                    public Response execute() {
+                        subject.execute();
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source, metadata(builder -> builder
+                .addMethod(MethodMetadata.builder()
+                        .name("execute")
+                        .returnType("void")
+                        .build())));
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("public void execute()");
+    }
+
+    private GeneratedTestContext contextFor(String source, ClassMetadata metadata) {
         GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleTest", source);
-        return new GeneratedTestContext(generated, null, java.util.List.of());
+        return new GeneratedTestContext(generated, metadata, java.util.List.of());
+    }
+
+    private ClassMetadata metadata(java.util.function.UnaryOperator<ClassMetadata.Builder> customiser) {
+        ClassMetadata.Builder builder = ClassMetadata.builder()
+                .packageName("com.example")
+                .className("Subject");
+        return customiser.apply(builder).build();
     }
 }

--- a/src/test/java/com/example/tests/generator/verification/rules/MockitoCompilationFixRuleTest.java
+++ b/src/test/java/com/example/tests/generator/verification/rules/MockitoCompilationFixRuleTest.java
@@ -1,0 +1,77 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.verification.GeneratedTestContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MockitoCompilationFixRuleTest {
+
+    private final MockitoCompilationFixRule rule = new MockitoCompilationFixRule();
+
+    @Test
+    void addsExtendWithAnnotationAndMockitoImportsWhenMocksArePresent() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.Test;
+
+                public class SampleTest {
+
+                    @Mock
+                    private Dependency dependency;
+
+                    @Test
+                    void usesMockito() {
+                        Mockito.when(dependency.call()).thenReturn("value");
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).contains("@ExtendWith(MockitoExtension.class)");
+        assertThat(updated).contains("import org.mockito.Mock;");
+        assertThat(updated).contains("import org.mockito.Mockito;");
+        assertThat(updated).contains("import org.junit.jupiter.api.extension.ExtendWith;");
+        assertThat(updated).contains("import org.mockito.junit.jupiter.MockitoExtension;");
+    }
+
+    @Test
+    void doesNotDuplicateExtendWithAnnotationWhenAlreadyPresent() {
+        String source = """
+                package com.example;
+
+                import org.junit.jupiter.api.extension.ExtendWith;
+                import org.mockito.junit.jupiter.MockitoExtension;
+                import org.mockito.Mock;
+
+                @ExtendWith(MockitoExtension.class)
+                public class SampleTest {
+
+                    @Mock
+                    private Dependency dependency;
+
+                    @Test
+                    void usesMockito() {
+                        dependency.toString();
+                    }
+                }
+                """;
+        GeneratedTestContext context = contextFor(source);
+
+        rule.apply(context);
+
+        String updated = context.getSourceCode();
+        assertThat(updated).containsOnlyOnce("@ExtendWith(MockitoExtension.class)");
+        assertThat(updated).contains("import org.mockito.Mock;");
+    }
+
+    private GeneratedTestContext contextFor(String source) {
+        GeneratedTestClass generated = new GeneratedTestClass("com.example", "SampleTest", source);
+        return new GeneratedTestContext(generated, null, java.util.List.of());
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable verification package with rules for imports, method signatures, dependency cleanup, and Mockito fixes
- integrate the verifier into the CLI to sanitize generated classes and retry compilation with automatic fixes
- add a unit test covering the default verifier behaviour

## Testing
- ./gradlew test *(fails: gradle wrapper jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ee3f575e0c8320b182f802e9c33e97