### PR TITLE
Add dependency introspection package with caching

### DIFF
--- a/src/main/java/com/example/tests/generator/introspection/ClassIntrospectionResult.java
+++ b/src/main/java/com/example/tests/generator/introspection/ClassIntrospectionResult.java
@@ -1,0 +1,76 @@
+package com.example.tests.generator.introspection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregated description of a class including its constructors and methods.
+ */
+public record ClassIntrospectionResult(
+        String className,
+        String packageName,
+        String superClassName,
+        List<String> interfaceNames,
+        List<String> annotations,
+        List<ConstructorDescription> constructors,
+        List<MethodDescription> methods
+) {
+
+    public ClassIntrospectionResult {
+        Objects.requireNonNull(className, "className");
+        Objects.requireNonNull(packageName, "packageName");
+        Objects.requireNonNull(interfaceNames, "interfaceNames");
+        Objects.requireNonNull(annotations, "annotations");
+        Objects.requireNonNull(constructors, "constructors");
+        Objects.requireNonNull(methods, "methods");
+        interfaceNames = List.copyOf(interfaceNames);
+        annotations = List.copyOf(annotations);
+        constructors = List.copyOf(constructors);
+        methods = List.copyOf(methods);
+    }
+
+    /**
+     * Creates a textual representation of the collected information suitable for prompt usage.
+     */
+    public String formatAsText() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Class: ").append(className);
+        if (!packageName.isEmpty()) {
+            builder.append(" (package ").append(packageName).append(")");
+        }
+        builder.append(System.lineSeparator());
+        if (superClassName != null && !superClassName.equals(Object.class.getName())) {
+            builder.append("  Extends: ").append(superClassName).append(System.lineSeparator());
+        }
+        if (!interfaceNames.isEmpty()) {
+            builder.append("  Implements: ").append(String.join(", ", interfaceNames)).append(System.lineSeparator());
+        }
+        if (!annotations.isEmpty()) {
+            builder.append("  Annotations: ").append(String.join(", ", annotations)).append(System.lineSeparator());
+        }
+        if (!constructors.isEmpty()) {
+            builder.append("  Constructors:").append(System.lineSeparator());
+            for (ConstructorDescription constructor : constructors) {
+                builder.append("    - ").append(constructor.signature()).append(System.lineSeparator());
+            }
+        }
+        if (!methods.isEmpty()) {
+            builder.append("  Methods:").append(System.lineSeparator());
+            for (MethodDescription method : methods) {
+                builder.append("    - ").append(method.signature()).append(System.lineSeparator());
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Combines constructor and method signatures into a single list.
+     */
+    public List<String> allSignatures() {
+        List<String> signatures = new ArrayList<>(constructors.size() + methods.size());
+        constructors.stream().map(ConstructorDescription::signature).forEach(signatures::add);
+        methods.stream().map(MethodDescription::signature).forEach(signatures::add);
+        return signatures;
+    }
+}

--- a/src/main/java/com/example/tests/generator/introspection/ConstructorDescription.java
+++ b/src/main/java/com/example/tests/generator/introspection/ConstructorDescription.java
@@ -1,0 +1,50 @@
+package com.example.tests.generator.introspection;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes a constructor that was discovered during dependency introspection.
+ */
+public record ConstructorDescription(
+        String declaringClass,
+        String name,
+        List<String> modifiers,
+        List<String> parameterTypes,
+        List<String> parameterNames,
+        List<String> exceptionTypes,
+        List<String> annotations,
+        boolean varArgs
+) {
+
+    public ConstructorDescription {
+        Objects.requireNonNull(declaringClass, "declaringClass");
+        Objects.requireNonNull(name, "name");
+        modifiers = List.copyOf(modifiers);
+        parameterTypes = List.copyOf(parameterTypes);
+        parameterNames = List.copyOf(parameterNames);
+        exceptionTypes = List.copyOf(exceptionTypes);
+        annotations = List.copyOf(annotations);
+    }
+
+    /**
+     * Returns a human-readable representation of the constructor signature.
+     */
+    public String signature() {
+        String params = IntrospectionFormatter.joinParameters(parameterTypes, parameterNames, varArgs);
+        String throwsPart = exceptionTypes.isEmpty()
+                ? ""
+                : " throws " + String.join(", ", exceptionTypes);
+        String modifiersPart = modifiers.isEmpty()
+                ? ""
+                : String.join(" ", modifiers) + " ";
+        return modifiersPart + name + "(" + params + ")" + throwsPart;
+    }
+
+    /**
+     * Unique signature used for sorting and equality comparisons.
+     */
+    public String qualifiedSignature() {
+        return declaringClass + "#" + name + "(" + String.join(",", parameterTypes) + ")";
+    }
+}

--- a/src/main/java/com/example/tests/generator/introspection/DependencyIntrospector.java
+++ b/src/main/java/com/example/tests/generator/introspection/DependencyIntrospector.java
@@ -1,0 +1,226 @@
+package com.example.tests.generator.introspection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Utility capable of introspecting classes, objects and methods from dependencies
+ * and providing structured descriptions that can be embedded into prompts.
+ */
+public class DependencyIntrospector {
+
+    private final Map<Class<?>, ClassIntrospectionResult> classCache = new ConcurrentHashMap<>();
+    private final Map<MethodCacheKey, MethodDescription> methodCache = new ConcurrentHashMap<>();
+    private final Map<ConstructorCacheKey, ConstructorDescription> constructorCache = new ConcurrentHashMap<>();
+
+    /**
+     * Inspects the runtime class of the provided object.
+     */
+    public ClassIntrospectionResult introspect(Object instance) {
+        Objects.requireNonNull(instance, "instance");
+        return introspect(instance.getClass());
+    }
+
+    /**
+     * Inspects the provided class. Results are cached to avoid repeated expensive lookups.
+     */
+    public ClassIntrospectionResult introspect(Class<?> clazz) {
+        Objects.requireNonNull(clazz, "clazz");
+        return classCache.computeIfAbsent(clazz, this::createClassDescription);
+    }
+
+    /**
+     * Inspects an individual method.
+     */
+    public MethodDescription introspect(Method method) {
+        Objects.requireNonNull(method, "method");
+        return methodCache.computeIfAbsent(MethodCacheKey.from(method), key -> createMethodDescription(method));
+    }
+
+    /**
+     * Inspects an individual constructor.
+     */
+    public ConstructorDescription introspect(Constructor<?> constructor) {
+        Objects.requireNonNull(constructor, "constructor");
+        return constructorCache.computeIfAbsent(ConstructorCacheKey.from(constructor),
+                key -> createConstructorDescription(constructor));
+    }
+
+    /**
+     * Clears all cached results. Mostly useful in tests.
+     */
+    public void clearCache() {
+        classCache.clear();
+        methodCache.clear();
+        constructorCache.clear();
+    }
+
+    private ClassIntrospectionResult createClassDescription(Class<?> clazz) {
+        String packageName = clazz.getPackage() == null ? "" : clazz.getPackageName();
+        String superClassName = clazz.getSuperclass() == null ? null : clazz.getSuperclass().getName();
+        List<String> interfaceNames = Arrays.stream(clazz.getInterfaces())
+                .map(Class::getName)
+                .sorted()
+                .toList();
+        List<String> annotations = readAnnotations(clazz.getAnnotations());
+
+        List<ConstructorDescription> constructors = Arrays.stream(clazz.getDeclaredConstructors())
+                .map(this::introspect)
+                .sorted((left, right) -> left.qualifiedSignature().compareTo(right.qualifiedSignature()))
+                .toList();
+
+        List<MethodDescription> methods = collectAllMethods(clazz).stream()
+                .sorted((left, right) -> left.qualifiedSignature().compareTo(right.qualifiedSignature()))
+                .toList();
+
+        return new ClassIntrospectionResult(
+                clazz.getName(),
+                packageName,
+                superClassName,
+                interfaceNames,
+                annotations,
+                constructors,
+                methods
+        );
+    }
+
+    private Collection<MethodDescription> collectAllMethods(Class<?> clazz) {
+        Map<String, MethodDescription> result = new ConcurrentHashMap<>();
+
+        for (Method method : clazz.getDeclaredMethods()) {
+            MethodDescription description = introspect(method);
+            result.putIfAbsent(description.qualifiedSignature(), description);
+        }
+
+        for (Method method : clazz.getMethods()) {
+            MethodDescription description = introspect(method);
+            result.putIfAbsent(description.qualifiedSignature(), description);
+        }
+
+        // Explore interfaces explicitly to catch non-public defaults.
+        Deque<Class<?>> queue = new ArrayDeque<>(List.of(clazz));
+        Set<Class<?>> visited = ConcurrentHashMap.newKeySet();
+        while (!queue.isEmpty()) {
+            Class<?> current = queue.removeFirst();
+            if (!visited.add(current)) {
+                continue;
+            }
+            for (Class<?> iface : current.getInterfaces()) {
+                queue.addLast(iface);
+                for (Method method : iface.getDeclaredMethods()) {
+                    MethodDescription description = introspect(method);
+                    result.putIfAbsent(description.qualifiedSignature(), description);
+                }
+            }
+        }
+
+        return result.values();
+    }
+
+    private MethodDescription createMethodDescription(Method method) {
+        List<String> modifiers = modifiers(method.getModifiers());
+        List<String> parameterTypes = Arrays.stream(method.getGenericParameterTypes())
+                .map(type -> type.getTypeName())
+                .toList();
+        List<String> parameterNames = readParameterNames(method.getParameters());
+        List<String> exceptionTypes = Arrays.stream(method.getExceptionTypes())
+                .map(Class::getName)
+                .toList();
+        List<String> annotations = readAnnotations(method.getAnnotations());
+        return new MethodDescription(
+                method.getDeclaringClass().getName(),
+                method.getName(),
+                method.getGenericReturnType().getTypeName(),
+                modifiers,
+                parameterTypes,
+                parameterNames,
+                exceptionTypes,
+                annotations,
+                method.isDefault(),
+                method.isVarArgs()
+        );
+    }
+
+    private ConstructorDescription createConstructorDescription(Constructor<?> constructor) {
+        List<String> modifiers = modifiers(constructor.getModifiers());
+        List<String> parameterTypes = Arrays.stream(constructor.getGenericParameterTypes())
+                .map(type -> type.getTypeName())
+                .toList();
+        List<String> parameterNames = readParameterNames(constructor.getParameters());
+        List<String> exceptionTypes = Arrays.stream(constructor.getExceptionTypes())
+                .map(Class::getName)
+                .toList();
+        List<String> annotations = readAnnotations(constructor.getAnnotations());
+        return new ConstructorDescription(
+                constructor.getDeclaringClass().getName(),
+                constructor.getDeclaringClass().getSimpleName(),
+                modifiers,
+                parameterTypes,
+                parameterNames,
+                exceptionTypes,
+                annotations,
+                constructor.isVarArgs()
+        );
+    }
+
+    private List<String> readParameterNames(Parameter[] parameters) {
+        List<String> names = new ArrayList<>(parameters.length);
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = parameters[i];
+            String fallback = "arg" + i;
+            names.add(parameter.isNamePresent() ? parameter.getName() : fallback);
+        }
+        return names;
+    }
+
+    private List<String> readAnnotations(Annotation[] annotations) {
+        return Arrays.stream(annotations)
+                .map(annotation -> annotation.annotationType().getName())
+                .sorted()
+                .toList();
+    }
+
+    private List<String> modifiers(int modifiers) {
+        String text = Modifier.toString(modifiers);
+        if (text.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(text.split(" "))
+                .map(String::trim)
+                .filter(part -> !part.isEmpty())
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private record MethodCacheKey(String declaringClass, String name, List<Class<?>> parameterTypes) {
+        static MethodCacheKey from(Method method) {
+            return new MethodCacheKey(
+                    method.getDeclaringClass().getName(),
+                    method.getName(),
+                    List.of(method.getParameterTypes())
+            );
+        }
+    }
+
+    private record ConstructorCacheKey(String declaringClass, List<Class<?>> parameterTypes) {
+        static ConstructorCacheKey from(Constructor<?> constructor) {
+            return new ConstructorCacheKey(
+                    constructor.getDeclaringClass().getName(),
+                    List.of(constructor.getParameterTypes())
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/tests/generator/introspection/IntrospectionFormatter.java
+++ b/src/main/java/com/example/tests/generator/introspection/IntrospectionFormatter.java
@@ -1,0 +1,27 @@
+package com.example.tests.generator.introspection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+final class IntrospectionFormatter {
+
+    private IntrospectionFormatter() {
+    }
+
+    static String joinParameters(List<String> parameterTypes, List<String> parameterNames, boolean varArgs) {
+        Objects.requireNonNull(parameterTypes, "parameterTypes");
+        Objects.requireNonNull(parameterNames, "parameterNames");
+
+        List<String> parts = new ArrayList<>(parameterTypes.size());
+        for (int i = 0; i < parameterTypes.size(); i++) {
+            String type = parameterTypes.get(i);
+            if (varArgs && i == parameterTypes.size() - 1) {
+                type = type.replace("[]", "...");
+            }
+            String name = parameterNames.size() > i ? parameterNames.get(i) : "arg" + i;
+            parts.add(type + " " + name);
+        }
+        return String.join(", ", parts);
+    }
+}

--- a/src/main/java/com/example/tests/generator/introspection/MethodDescription.java
+++ b/src/main/java/com/example/tests/generator/introspection/MethodDescription.java
@@ -1,0 +1,53 @@
+package com.example.tests.generator.introspection;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes a method that was discovered during dependency introspection.
+ */
+public record MethodDescription(
+        String declaringClass,
+        String name,
+        String returnType,
+        List<String> modifiers,
+        List<String> parameterTypes,
+        List<String> parameterNames,
+        List<String> exceptionTypes,
+        List<String> annotations,
+        boolean defaultMethod,
+        boolean varArgs
+) {
+
+    public MethodDescription {
+        Objects.requireNonNull(declaringClass, "declaringClass");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(returnType, "returnType");
+        modifiers = List.copyOf(modifiers);
+        parameterTypes = List.copyOf(parameterTypes);
+        parameterNames = List.copyOf(parameterNames);
+        exceptionTypes = List.copyOf(exceptionTypes);
+        annotations = List.copyOf(annotations);
+    }
+
+    /**
+     * Returns a unique signature identifying the method by declaring class and parameter types.
+     */
+    public String qualifiedSignature() {
+        return declaringClass + "#" + name + "(" + String.join(",", parameterTypes) + ")";
+    }
+
+    /**
+     * Returns a human-readable signature that can be embedded into prompts.
+     */
+    public String signature() {
+        String modifiersPart = modifiers.isEmpty()
+                ? ""
+                : String.join(" ", modifiers) + " ";
+        String params = IntrospectionFormatter.joinParameters(parameterTypes, parameterNames, varArgs);
+        String throwsPart = exceptionTypes.isEmpty()
+                ? ""
+                : " throws " + String.join(", ", exceptionTypes);
+        return modifiersPart + returnType + " " + name + "(" + params + ")" + throwsPart;
+    }
+}

--- a/src/test/java/com/example/tests/generator/introspection/DependencyIntrospectorTest.java
+++ b/src/test/java/com/example/tests/generator/introspection/DependencyIntrospectorTest.java
@@ -1,0 +1,113 @@
+package com.example.tests.generator.introspection;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DependencyIntrospectorTest {
+
+    private final DependencyIntrospector introspector = new DependencyIntrospector();
+
+    @AfterEach
+    void tearDown() {
+        introspector.clearCache();
+    }
+
+    @Test
+    void cachesClassDescriptions() {
+        ClassIntrospectionResult first = introspector.introspect(SampleComponent.class);
+        ClassIntrospectionResult second = introspector.introspect(SampleComponent.class);
+
+        assertThat(second).isSameAs(first);
+
+        SampleComponent component = new SampleComponent();
+        ClassIntrospectionResult fromObject = introspector.introspect(component);
+        assertThat(fromObject).isSameAs(first);
+    }
+
+    @Test
+    void cachesMethodAndConstructorDescriptions() throws Exception {
+        Method joinMethod = SampleComponent.class.getMethod("join", String.class);
+        MethodDescription methodFirst = introspector.introspect(joinMethod);
+        MethodDescription methodSecond = introspector.introspect(joinMethod);
+        assertThat(methodSecond).isSameAs(methodFirst);
+
+        Constructor<SampleComponent> ctor = SampleComponent.class.getConstructor(int.class);
+        ConstructorDescription ctorFirst = introspector.introspect(ctor);
+        ConstructorDescription ctorSecond = introspector.introspect(ctor);
+        assertThat(ctorSecond).isSameAs(ctorFirst);
+    }
+
+    @Test
+    void collectsInformationFromJdkClass() {
+        ClassIntrospectionResult result = introspector.introspect(LocalDate.class);
+
+        assertThat(result.className()).isEqualTo(LocalDate.class.getName());
+        assertThat(result.packageName()).isEqualTo("java.time");
+        assertThat(result.methods())
+                .as("LocalDate should contain parse factory method")
+                .anyMatch(method -> method.name().equals("parse")
+                        && method.returnType().equals(LocalDate.class.getName()));
+    }
+
+    @Test
+    void collectsInheritedMethodsFromDependencies() {
+        ClassIntrospectionResult result = introspector.introspect(SampleComponent.class);
+
+        assertThat(result.methods())
+                .anyMatch(method -> method.name().equals("add")
+                        && method.declaringClass().equals(ArrayList.class.getName()));
+
+        assertThat(result.methods())
+                .anyMatch(method -> method.name().equals("join")
+                        && method.declaringClass().equals(SampleComponent.class.getName())
+                        && method.signature().contains("java.lang.String delimiter"));
+    }
+
+    @Test
+    void methodIntrospectionReturnsDetailedSignature() throws Exception {
+        Method method = List.class.getMethod("stream");
+        MethodDescription description = introspector.introspect(method);
+
+        assertThat(description.returnType()).isEqualTo("java.util.stream.Stream<E>");
+        assertThat(description.signature()).contains("Stream<E> stream()");
+    }
+
+    @Test
+    void formattedOutputContainsConstructorsAndMethods() {
+        ClassIntrospectionResult result = introspector.introspect(SampleComponent.class);
+        String formatted = result.formatAsText();
+
+        assertThat(formatted).contains("Class: " + SampleComponent.class.getName());
+        assertThat(formatted).contains("Constructors:");
+        assertThat(formatted).contains("Methods:");
+        assertThat(formatted).contains("join(java.lang.String delimiter)");
+    }
+
+    static class SampleComponent extends ArrayList<String> {
+
+        SampleComponent() {
+            super();
+        }
+
+        SampleComponent(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        public String join(String delimiter) {
+            return String.join(delimiter, this);
+        }
+
+        @Deprecated
+        public void legacyMethod() {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an introspection utility that inspects classes, objects, and members with caching
- expose structured constructor and method descriptions that can be embedded into prompts
- add unit tests that demonstrate metadata discovery across project and JDK types

## Testing
- gradle test *(fails: unable to download Maven dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef8b85940c8320b4d528a340667ee1