### PR TITLE
Scope orchestration fix prompts for diff-mode workflows

### DIFF
--- a/examples/discount-service/build.gradle
+++ b/examples/discount-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'

--- a/examples/discount-service/src/main/java/com/acme/discount/OrderTestInspector.java
+++ b/examples/discount-service/src/main/java/com/acme/discount/OrderTestInspector.java
@@ -1,0 +1,156 @@
+package com.acme.discount;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+/**
+ * Utility that inspects {@link Order} and describes the collaborators that
+ * should be mocked when generating tests.
+ */
+public final class OrderTestInspector {
+
+    private OrderTestInspector() {
+    }
+
+    /**
+     * Analyses the provided method name and returns a list of fully qualified
+     * dependency type names that should be mocked.
+     *
+     * @param methodName the Order method to inspect
+     * @return ordered list of dependency type names
+     */
+    public static List<String> inspectDependenciesFor(String methodName) {
+        Set<String> dependencies = new LinkedHashSet<>();
+        Class<Order> clazz = Order.class;
+
+        addFieldDependencies(clazz, dependencies);
+        addConstructorDependencies(clazz, dependencies);
+
+        if (methodName == null || methodName.isBlank()) {
+            return new ArrayList<>(dependencies);
+        }
+
+        if ("<init>".equals(methodName) || Order.class.getSimpleName().equals(methodName)) {
+            return new ArrayList<>(dependencies);
+        }
+
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                addType(dependencies, method.getGenericReturnType());
+                for (Type parameterType : method.getGenericParameterTypes()) {
+                    addType(dependencies, parameterType);
+                }
+            }
+        }
+
+        dependencies.remove(clazz.getName());
+        return new ArrayList<>(dependencies);
+    }
+
+    /**
+     * Creates an example snippet that shows how to mock dependencies for the
+     * requested method.
+     *
+     * @param methodName Order method that will be exercised
+     * @return code sample containing Mockito-based mocks
+     */
+    public static String generateMockConstructor(String methodName) {
+        List<String> dependencies = inspectDependenciesFor(methodName);
+        StringBuilder builder = new StringBuilder();
+        builder.append("// Example mock constructor for method ")
+                .append(methodName == null ? "<unknown>" : methodName)
+                .append('\n');
+
+        for (String dependency : dependencies) {
+            if (dependency.equals(Order.class.getName())) {
+                continue;
+            }
+            String simpleName = simpleName(dependency);
+            builder.append(dependency)
+                    .append(' ')
+                    .append(decapitalize(simpleName) + "Mock")
+                    .append(" = Mockito.mock(")
+                    .append(dependency)
+                    .append(".class);\n");
+        }
+
+        builder.append("java.util.List<")
+                .append(OrderLine.class.getName())
+                .append("> orderLines = new java.util.ArrayList<>();\n");
+        builder.append("orderLines.add(Mockito.mock(")
+                .append(OrderLine.class.getName())
+                .append(".class));\n");
+        builder.append(Order.class.getName())
+                .append(" order = new ")
+                .append(Order.class.getName())
+                .append("(\"order-123\", java.time.LocalDate.now(), orderLines);\n");
+        builder.append("return order;\n");
+        return builder.toString();
+    }
+
+    private static void addFieldDependencies(Class<?> clazz, Set<String> dependencies) {
+        for (Field field : clazz.getDeclaredFields()) {
+            addType(dependencies, field.getGenericType());
+        }
+    }
+
+    private static void addConstructorDependencies(Class<?> clazz, Set<String> dependencies) {
+        for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+            for (Type parameterType : constructor.getGenericParameterTypes()) {
+                addType(dependencies, parameterType);
+            }
+        }
+    }
+
+    private static void addType(Set<String> dependencies, Type type) {
+        if (type == null) {
+            return;
+        }
+        if (type instanceof Class<?> clazz) {
+            addClass(dependencies, clazz);
+        } else if (type instanceof ParameterizedType parameterizedType) {
+            addType(dependencies, parameterizedType.getRawType());
+            for (Type argument : parameterizedType.getActualTypeArguments()) {
+                addType(dependencies, argument);
+            }
+        } else if (type instanceof GenericArrayType arrayType) {
+            addType(dependencies, arrayType.getGenericComponentType());
+        }
+    }
+
+    private static void addClass(Set<String> dependencies, Class<?> clazz) {
+        if (clazz == null || clazz.isPrimitive()) {
+            return;
+        }
+        dependencies.add(clazz.getName());
+        Class<?> componentType = clazz.getComponentType();
+        if (componentType != null) {
+            addClass(dependencies, componentType);
+        }
+    }
+
+    private static String simpleName(String qualifiedName) {
+        int lastDot = qualifiedName.lastIndexOf('.');
+        return lastDot >= 0 ? qualifiedName.substring(lastDot + 1) : qualifiedName;
+    }
+
+    private static String decapitalize(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        if (value.length() == 1) {
+            return value.toLowerCase();
+        }
+        return Character.toLowerCase(value.charAt(0)) + value.substring(1);
+    }
+}

--- a/examples/discount-service/src/test/java/com/acme/discount/OrderTest.java
+++ b/examples/discount-service/src/test/java/com/acme/discount/OrderTest.java
@@ -1,0 +1,154 @@
+package com.acme.discount;
+
+import static java.lang.Double.compare;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class OrderTest {
+
+    @Test
+    void testConstructorWithValidArguments() {
+        String orderId = "1234";
+        LocalDate orderDate = LocalDate.of(2023, 10, 1);
+        List<OrderLine> lines = new ArrayList<>();
+        lines.add(new OrderLine("SKU1", ProductCategory.ELECTRONICS, 2, 100.0));
+        lines.add(new OrderLine("SKU2", ProductCategory.FASHION, 1, 50.0));
+
+        Order order = new Order(orderId, orderDate, lines);
+
+        assertEquals(orderId, order.getOrderId());
+        assertEquals(orderDate, order.getOrderDate());
+        assertEquals(lines, order.getLines());
+    }
+
+    @Test
+    void constructorShouldSetFieldsCorrectly() {
+        String orderId = "1234";
+        LocalDate orderDate = LocalDate.of(2023, 10, 1);
+        List<OrderLine> lines = new ArrayList<>();
+        lines.add(new OrderLine("SKU3", ProductCategory.GROCERY, 3, 25.0));
+        lines.add(new OrderLine("SKU4", ProductCategory.HOME, 2, 40.0));
+
+        Order order = new Order(orderId, orderDate, lines);
+
+        assertEquals(2, order.getLines().size());
+        assertEquals(orderDate, order.getOrderDate());
+    }
+
+    @Test
+    void testGetCustomerId() {
+        String expectedCustomerId = "C1234";
+        LocalDate orderDate = LocalDate.of(2023, 9, 1);
+        List<OrderLine> lines = singletonList(new OrderLine("SKU1", ProductCategory.GROCERY, 1, 10.0));
+        Order order = new Order(expectedCustomerId, orderDate, lines);
+
+        String actualCustomerId = order.getOrderId();
+
+        assertEquals(expectedCustomerId, actualCustomerId);
+    }
+
+    @Test
+    void testGetOrderDate() {
+        LocalDate expectedDate = LocalDate.of(2023, 10, 1);
+        List<OrderLine> lines = singletonList(new OrderLine("SKU2", ProductCategory.ELECTRONICS, 1, 15.0));
+        Order order = new Order("ORDER_001", expectedDate, lines);
+
+        LocalDate result = order.getOrderDate();
+
+        assertEquals(expectedDate, result);
+    }
+
+    @Test
+    void testGetLinesReturnsCorrectLines() {
+        List<OrderLine> expectedLines = Arrays.asList(
+                new OrderLine("SKU1", ProductCategory.ELECTRONICS, 2, 100.0),
+                new OrderLine("SKU2", ProductCategory.FASHION, 1, 80.0));
+        Order order = new Order("ORDER_002", LocalDate.now(), expectedLines);
+
+        List<OrderLine> actualLines = order.getLines();
+
+        assertEquals(expectedLines, actualLines);
+    }
+
+    @Test
+    void getLinesReturnsProvidedLines() {
+        List<OrderLine> expectedLines = Arrays.asList(
+                new OrderLine("SKU3", ProductCategory.SPORTS, 1, 120.0));
+        Order order = new Order("ORDER_003", LocalDate.now(), expectedLines);
+
+        List<OrderLine> actualLines = order.getLines();
+
+        assertEquals(expectedLines, actualLines);
+    }
+
+    @Test
+    void getSubtotalReturnsCorrectValue() {
+        List<OrderLine> lines = Arrays.asList(
+                new OrderLine("SKU4", ProductCategory.ELECTRONICS, 1, 200.0),
+                new OrderLine("SKU5", ProductCategory.FASHION, 2, 75.0));
+        Order order = new Order("ORDER_004", LocalDate.now(), lines);
+
+        double subtotal = order.getSubtotal();
+
+        assertTrue(compare(subtotal, 350.0) == 0, () -> "Expected subtotal 350.0 but was " + subtotal);
+    }
+
+    @Test
+    void testGetSubtotal() {
+        List<OrderLine> lines = Arrays.asList(
+                new OrderLine("SKU6", ProductCategory.GROCERY, 3, 20.0),
+                new OrderLine("SKU7", ProductCategory.GROCERY, 1, 15.0));
+        Order order = new Order("ORDER_005", LocalDate.now(), lines);
+
+        double subtotal = order.getSubtotal();
+
+        assertTrue(compare(subtotal, 75.0) == 0, () -> "Expected subtotal 75.0 but was " + subtotal);
+    }
+
+    @Test
+    void testGetSubtotalForCategory() {
+        List<OrderLine> lines = Arrays.asList(
+                new OrderLine("SKU8", ProductCategory.ELECTRONICS, 1, 100.0),
+                new OrderLine("SKU9", ProductCategory.ELECTRONICS, 2, 50.0),
+                new OrderLine("SKU10", ProductCategory.FASHION, 1, 60.0));
+        Order order = new Order("ORDER_006", LocalDate.now(), lines);
+
+        double subtotalForCategory = order.getSubtotalForCategory(ProductCategory.ELECTRONICS);
+
+        assertTrue(compare(subtotalForCategory, 200.0) == 0,
+                () -> "Expected subtotal for electronics to be 200.0 but was " + subtotalForCategory);
+    }
+
+    @Test
+    void testGetDominantCategory() {
+        List<OrderLine> lines = Arrays.asList(
+                new OrderLine("SKU11", ProductCategory.ELECTRONICS, 2, 150.0),
+                new OrderLine("SKU12", ProductCategory.FASHION, 1, 80.0));
+        Order order = new Order("ORDER_007", LocalDate.now(), lines);
+
+        Optional<ProductCategory> dominantCategory = order.getDominantCategory();
+
+        assertTrue(dominantCategory.isPresent());
+        assertEquals(ProductCategory.ELECTRONICS, dominantCategory.orElseThrow());
+    }
+
+    @Test
+    void testGetDominantCategoryWithSingleCategory() {
+        List<OrderLine> lines = singletonList(new OrderLine("SKU13", ProductCategory.FASHION, 1, 120.0));
+        Order order = new Order("ORDER_008", LocalDate.now(), lines);
+
+        Optional<ProductCategory> dominantCategory = order.getDominantCategory();
+
+        assertTrue(dominantCategory.isPresent());
+        assertEquals(ProductCategory.FASHION, dominantCategory.orElseThrow());
+    }
+}

--- a/src/main/java/com/example/tests/generator/cli/CliArguments.java
+++ b/src/main/java/com/example/tests/generator/cli/CliArguments.java
@@ -22,11 +22,13 @@ final class CliArguments {
     private final boolean executionSuccessEnabled;
     private final boolean focusDependencies;
     private final boolean mockValidationEnabled;
+    private final boolean diffMethodEnabled;
 
     private CliArguments(Path projectRoot, List<String> targetClasses, int maxRetries, int limit,
             Duration requestDelay, boolean useTokenAuth, boolean infoLogging,
             boolean compileSuccessEnabled, boolean executionSuccessEnabled,
-            boolean focusDependencies, boolean mockValidationEnabled) {
+            boolean focusDependencies, boolean mockValidationEnabled,
+            boolean diffMethodEnabled) {
         this.projectRoot = projectRoot;
         this.targetClasses = List.copyOf(targetClasses);
         this.maxRetries = maxRetries;
@@ -38,6 +40,7 @@ final class CliArguments {
         this.executionSuccessEnabled = executionSuccessEnabled;
         this.focusDependencies = focusDependencies;
         this.mockValidationEnabled = mockValidationEnabled;
+        this.diffMethodEnabled = diffMethodEnabled;
     }
 
     public Path projectRoot() {
@@ -84,6 +87,10 @@ final class CliArguments {
         return mockValidationEnabled;
     }
 
+    public boolean diffMethodEnabled() {
+        return diffMethodEnabled;
+    }
+
     public static CliArguments parse(String[] args) {
         Path project = Paths.get("").toAbsolutePath();
         List<String> targets = new ArrayList<>();
@@ -96,6 +103,7 @@ final class CliArguments {
         boolean executionSuccessEnabled = true;
         boolean focusDependencies = false;
         boolean mockValidationEnabled = false;
+        boolean diffMethodEnabled = false;
 
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
@@ -145,6 +153,9 @@ final class CliArguments {
                 case "--validateMocks":
                     mockValidationEnabled = parseBooleanFlag(arg, requireValue(arg, args, ++i));
                     break;
+                case "--diff-method":
+                    diffMethodEnabled = true;
+                    break;
                 case "--help":
                 case "-h":
                     throw new HelpRequestedException();
@@ -155,7 +166,7 @@ final class CliArguments {
 
         return new CliArguments(project.toAbsolutePath().normalize(), targets, maxRetries, limit,
                 requestDelay, useToken, infoLogging, compileSuccessEnabled, executionSuccessEnabled,
-                focusDependencies, mockValidationEnabled);
+                focusDependencies, mockValidationEnabled, diffMethodEnabled);
     }
 
     public static void printUsage() {
@@ -170,6 +181,7 @@ final class CliArguments {
         System.out.println("      --executionSuccess <b> Enable (true) or disable (false) the test execution rerun step");
         System.out.println("      --focusDependencies <b> Enable (true) or disable (false) focused dependency prompts");
         System.out.println("      --validateMocks <b> Enable (true) or disable (false) Gigachat validation of method mocks");
+        System.out.println("      --diff-method        Activate per-method diff generation workflow");
         System.out.println("      --token               Use OAuth token authentication instead of mTLS certificates");
         System.out.println("      --info                Enable detailed agent logging");
         System.out.println("  -h, --help               Show this help message");

--- a/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
+++ b/src/main/java/com/example/tests/generator/cli/TestGeneratorCli.java
@@ -5,6 +5,7 @@ import com.example.agent.providers.GigachatLLMClient;
 import com.example.agent.providers.LLMClient;
 import com.example.tests.generator.analysis.DependencyDocumentation;
 import com.example.tests.generator.analysis.TestDependencyDocumentationBuilder;
+import com.example.tests.generator.diff.DiffMethodGenerationRunner;
 import com.example.tests.generator.metadata.MetadataTransformer;
 import com.example.tests.generator.metadata.RelatedTypeMetadata;
 import com.example.tests.generator.model.ClassMetadata;
@@ -107,10 +108,29 @@ public final class TestGeneratorCli {
             return;
         }
 
+        List<ClassMetadata> limitedTargets = selected.stream()
+                .limit(arguments.limit())
+                .collect(Collectors.toList());
+
         GigachatClientConfig config = GigachatClientProperties.load();
         LLMClient llmClient = arguments.useTokenAuth()
                 ? new GigachatLLMClient(config)
                 : new GigaChatCertificateClient(config);
+
+        Duration requestDelay = arguments.requestDelay();
+
+        if (arguments.diffMethodEnabled()) {
+            DiffMethodGenerationRunner runner = new DiffMethodGenerationRunner(
+                    projectRoot,
+                    llmClient,
+                    arguments.maxRetries(),
+                    requestDelay,
+                    defaultOptions()
+            );
+            DiffMethodGenerationRunner.GenerationSummary summary = runner.execute(limitedTargets, discovered);
+            summary.printSummary();
+            return;
+        }
 
         List<MockRule> methodMockRules = List.of(
                 new StaticVoidInvocationRule(),
@@ -126,12 +146,10 @@ public final class TestGeneratorCli {
                 methodMockValidationService
         );
 
-        Duration requestDelay = arguments.requestDelay();
-
         List<GeneratedTestClass> generatedClasses = new ArrayList<>();
         Map<String, com.example.tests.generator.metadata.ClassMetadata> metadataByTestClass = new HashMap<>();
         long lastRequestAtNanos = -1L;
-        for (ClassMetadata metadata : selected.stream().limit(arguments.limit()).collect(Collectors.toList())) {
+        for (ClassMetadata metadata : limitedTargets) {
             LOGGER.info(() -> "Обработка класса: " + metadata.getQualifiedName());
             com.example.tests.generator.metadata.ClassMetadata promptMetadata = transformer.transform(metadata);
             DependencyDocumentation dependencyDocumentation = dependencyDocumentationBuilder.buildDocumentation(
@@ -308,9 +326,12 @@ public final class TestGeneratorCli {
             );
             if (!contexts.isEmpty()) {
                 PromptClient promptClient = llmClient::sendPrompt;
+                boolean methodScopedFixPrompts = arguments.diffMethodEnabled()
+                        && (arguments.compileSuccessEnabled() || arguments.executionSuccessEnabled());
                 FixIterationExecutionSettings executionSettings = new FixIterationExecutionSettings(
                         arguments.compileSuccessEnabled(),
-                        arguments.executionSuccessEnabled());
+                        arguments.executionSuccessEnabled(),
+                        methodScopedFixPrompts);
                 TestSignatureVerifier signatureVerifier = new SignatureComplianceVerifier();
                 TestFixIterationCoordinator coordinator = new TestFixIterationCoordinator(
                         new GradleTestSuiteRunner(),

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -106,10 +106,12 @@ public class DiffMethodGenerationRunner {
         List<String> lastErrors = List.of();
         while (iterations <= maxRetries) {
             iterations++;
+            final int attempt = iterations;
+            final int totalAttempts = maxRetries + 1;
             String prompt = buildPrompt(classContext, owner, method, feedback);
             LOGGER.info(() -> String.format(Locale.ENGLISH,
                     "Формирование diff-method запроса (%d/%d) для %s#%s",
-                    iterations, maxRetries + 1, owner.getQualifiedName(), method.getName()));
+                    attempt, totalAttempts, owner.getQualifiedName(), method.getName()));
             String response = sendPrompt(prompt);
             Optional<String> methodSource = extractMethod(response, method.getName());
             if (methodSource.isEmpty()) {

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -6,9 +6,16 @@ import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.model.MethodMetadata;
 import com.example.tests.generator.model.MethodMetadata.Parameter;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.util.StandardLibraryTypeResolver;
 import com.example.tests.generator.validate.ResponseValidator;
 import com.example.tests.generator.validate.ValidationResult;
 import com.example.tests.generator.verification.GeneratedTestVerifier;
+import com.example.tests.orchestration.analysis.DependencyNode;
+import com.example.tests.orchestration.analysis.InvocationArgument;
+import com.example.tests.orchestration.analysis.MethodDependencyAnalyzer;
+import com.example.tests.orchestration.analysis.MethodDependencyGraph;
+import com.example.tests.orchestration.analysis.MethodInvocation;
+import com.example.tests.orchestration.analysis.MethodParameter;
 
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -62,6 +69,7 @@ public class DiffMethodGenerationRunner {
     private final Path testSourcesRoot;
     private final ResponseValidator responseValidator;
     private final GeneratedTestVerifier testVerifier;
+    private final MethodDependencyAnalyzer methodDependencyAnalyzer;
     private static final Pattern VAR_PATTERN = Pattern.compile("\\bvar\\b");
     private long lastRequestAtNanos;
 
@@ -85,6 +93,7 @@ public class DiffMethodGenerationRunner {
         this.testSourcesRoot = projectRoot.resolve(Paths.get("src", "test", "java"));
         this.responseValidator = new ResponseValidator();
         this.testVerifier = new GeneratedTestVerifier();
+        this.methodDependencyAnalyzer = new MethodDependencyAnalyzer();
         this.lastRequestAtNanos = -1L;
     }
 
@@ -176,11 +185,13 @@ public class DiffMethodGenerationRunner {
         List<String> previousCompilationErrors = List.of();
         List<Path> projectSources = collectCompilationSources(owner, metadataIndex);
         com.example.tests.generator.metadata.ClassMetadata promptMetadata = metadataTransformer.transform(owner);
+        MethodDependencyInfo methodDependencies = inspectMethodDependencies(owner, method, metadataTransformer);
         while (iterations <= maxRetries) {
             iterations++;
             final int attempt = iterations;
             final int totalAttempts = maxRetries + 1;
-            String prompt = buildPrompt(classContext, owner, method, feedback, metadataIndex, discoveredList, testClassName);
+            String prompt = buildPrompt(classContext, owner, method, feedback, metadataIndex, discoveredList,
+                    methodDependencies, testClassName);
             LOGGER.info(() -> String.format(Locale.ENGLISH,
                     "Формирование diff-method запроса (%d/%d) для %s#%s",
                     attempt, totalAttempts, owner.getQualifiedName(), method.getName()));
@@ -233,18 +244,38 @@ public class DiffMethodGenerationRunner {
         return new MethodGenerationStatus(owner.getQualifiedName(), method.getName(), compiled, iterations, lastErrors);
     }
 
+    private MethodDependencyInfo inspectMethodDependencies(ClassMetadata owner,
+                                                           MethodMetadata method,
+                                                           MetadataTransformer metadataTransformer) {
+        if (owner.getSourcePath() == null) {
+            return MethodDependencyInfo.empty();
+        }
+        String analyzerMethodName = method.isConstructor() ? "<init>" : method.getName();
+        try {
+            MethodDependencyGraph graph = methodDependencyAnalyzer.analyze(owner.getSourcePath(),
+                    owner.getQualifiedName(), analyzerMethodName);
+            return MethodDependencyInfo.from(graph, owner, metadataTransformer);
+        } catch (RuntimeException ex) {
+            LOGGER.warning(() -> String.format(Locale.ENGLISH,
+                    "Не удалось проанализировать зависимости метода %s#%s: %s",
+                    owner.getQualifiedName(), method.getName(), ex.getMessage()));
+            return MethodDependencyInfo.empty();
+        }
+    }
+
     private String buildPrompt(String classContext,
                                ClassMetadata owner,
                                MethodMetadata method,
                                List<String> previousErrors,
                                Map<String, ClassMetadata> metadataIndex,
                                List<ClassMetadata> discoveredList,
+                               MethodDependencyInfo methodDependencies,
                                String testClassName) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("Вы — помощник, который пишет модульные тесты на JUnit 5.\n");
         prompt.append("class_api_context = ").append(classContext).append('\n');
         prompt.append("target_method = ").append(describeMethod(owner, method)).append('\n');
-        String apiReference = buildApiReference(owner, metadataIndex, discoveredList);
+        String apiReference = buildApiReference(owner, metadataIndex, discoveredList, methodDependencies);
         if (!apiReference.isBlank()) {
             prompt.append("available_api_signatures:\n");
             prompt.append(apiReference);
@@ -280,7 +311,8 @@ public class DiffMethodGenerationRunner {
 
     private String buildApiReference(ClassMetadata owner,
                                      Map<String, ClassMetadata> metadataIndex,
-                                     List<ClassMetadata> discoveredList) {
+                                     List<ClassMetadata> discoveredList,
+                                     MethodDependencyInfo methodDependencies) {
         StringBuilder builder = new StringBuilder();
         List<MethodMetadata> ownerMethods = owner.getMethods().stream()
                 .filter(MethodMetadata::isPublic)
@@ -293,6 +325,11 @@ public class DiffMethodGenerationRunner {
         }
 
         Set<String> dependencies = new LinkedHashSet<>(owner.getDependencies());
+        if (methodDependencies != null) {
+            methodDependencies.domainTypes().stream()
+                    .map(ClassMetadata::getQualifiedName)
+                    .forEach(dependencies::add);
+        }
         if (!dependencies.isEmpty()) {
             if (builder.length() > 0) {
                 builder.append(System.lineSeparator());
@@ -339,7 +376,157 @@ public class DiffMethodGenerationRunner {
             }
         }
 
+        if (methodDependencies != null && !methodDependencies.standardTypes().isEmpty()) {
+            if (builder.length() > 0) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("- Стандартные классы Java, используемые методом: ")
+                    .append(System.lineSeparator());
+            for (String type : methodDependencies.standardTypes()) {
+                builder.append("  * ").append(type).append(System.lineSeparator());
+            }
+        }
+
         return builder.toString();
+    }
+
+    private static final class MethodDependencyInfo {
+
+        private final List<ClassMetadata> domainTypes;
+        private final List<String> standardTypes;
+
+        private MethodDependencyInfo(List<ClassMetadata> domainTypes, List<String> standardTypes) {
+            this.domainTypes = Collections.unmodifiableList(new ArrayList<>(domainTypes));
+            this.standardTypes = Collections.unmodifiableList(new ArrayList<>(standardTypes));
+        }
+
+        static MethodDependencyInfo empty() {
+            return new MethodDependencyInfo(List.of(), List.of());
+        }
+
+        static MethodDependencyInfo from(MethodDependencyGraph graph,
+                                         ClassMetadata owner,
+                                         MetadataTransformer metadataTransformer) {
+            if (graph == null) {
+                return empty();
+            }
+            LinkedHashSet<ClassMetadata> domain = new LinkedHashSet<>();
+            LinkedHashSet<String> standard = new LinkedHashSet<>();
+            String ownerQualifiedName = owner.getQualifiedName();
+            String ownerPackage = owner.getPackageName();
+
+            for (MethodParameter parameter : graph.getParameters()) {
+                registerType(parameter.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            }
+            for (DependencyNode dependency : graph.getDependencies()) {
+                traverseDependency(dependency, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            }
+            for (MethodInvocation invocation : graph.getUnattachedInvocations()) {
+                for (InvocationArgument argument : invocation.getArguments()) {
+                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                }
+            }
+
+            return new MethodDependencyInfo(new ArrayList<>(domain), new ArrayList<>(standard));
+        }
+
+        List<ClassMetadata> domainTypes() {
+            return domainTypes;
+        }
+
+        List<String> standardTypes() {
+            return standardTypes;
+        }
+
+        private static void traverseDependency(DependencyNode node,
+                                               String ownerPackage,
+                                               String ownerQualifiedName,
+                                               MetadataTransformer metadataTransformer,
+                                               Set<ClassMetadata> domain,
+                                               Set<String> standard) {
+            if (node == null) {
+                return;
+            }
+            registerType(node.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            registerType(node.getDeclaredType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            for (InvocationArgument argument : node.getConstructorArguments()) {
+                registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            }
+            for (MethodInvocation invocation : node.getMethodInvocations()) {
+                for (InvocationArgument argument : invocation.getArguments()) {
+                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                }
+            }
+            for (DependencyNode child : node.getDependencies()) {
+                traverseDependency(child, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            }
+        }
+
+        private static void registerType(String rawType,
+                                         String ownerPackage,
+                                         String ownerQualifiedName,
+                                         MetadataTransformer metadataTransformer,
+                                         Set<ClassMetadata> domain,
+                                         Set<String> standard) {
+            if (rawType == null || rawType.isBlank()) {
+                return;
+            }
+            for (String token : extractTypeTokens(rawType)) {
+                if (token.isBlank()) {
+                    continue;
+                }
+                Optional<ClassMetadata> resolved = metadataTransformer.resolveRawMetadata(token, ownerPackage);
+                if (resolved.isPresent()) {
+                    ClassMetadata metadata = resolved.get();
+                    if (!metadata.getQualifiedName().equals(ownerQualifiedName)) {
+                        domain.add(metadata);
+                    }
+                    continue;
+                }
+                StandardLibraryTypeResolver.resolve(token).ifPresent(standard::add);
+            }
+        }
+
+        private static Set<String> extractTypeTokens(String rawType) {
+            String cleaned = rawType.replace('<', ' ').replace('>', ' ')
+                    .replace('(', ' ').replace(')', ' ')
+                    .replace('[', ' ').replace(']', ' ')
+                    .replace(',', ' ').replace('?', ' ');
+            String[] parts = cleaned.split("\\s+");
+            Set<String> tokens = new LinkedHashSet<>();
+            for (String part : parts) {
+                String token = normaliseToken(part);
+                if (token.isEmpty()) {
+                    continue;
+                }
+                char first = token.charAt(0);
+                if (!Character.isLetter(first) || Character.isLowerCase(first)) {
+                    continue;
+                }
+                tokens.add(token);
+            }
+            return tokens;
+        }
+
+        private static String normaliseToken(String value) {
+            if (value == null) {
+                return "";
+            }
+            String trimmed = value.trim();
+            while (trimmed.endsWith("[]")) {
+                trimmed = trimmed.substring(0, trimmed.length() - 2);
+            }
+            if (trimmed.endsWith("...")) {
+                trimmed = trimmed.substring(0, trimmed.length() - 3);
+            }
+            while (trimmed.endsWith(".")) {
+                trimmed = trimmed.substring(0, trimmed.length() - 1);
+            }
+            if (trimmed.equalsIgnoreCase("null") || trimmed.equalsIgnoreCase("unknown")) {
+                return "";
+            }
+            return trimmed;
+        }
     }
 
     private String describeMethod(ClassMetadata owner, MethodMetadata method) {

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -118,29 +118,30 @@ public class DiffMethodGenerationRunner {
             }
             String classContext = buildClassContext(target, discovered);
             LOGGER.info(() -> "class_api_context для " + target.getQualifiedName() + ":\n" + classContext);
-            Path finalFile = prepareFinalTestFile(target);
+            String testClassName = resolveTestClassName(target);
+            Path finalFile = prepareFinalTestFile(target, testClassName);
             for (MethodMetadata method : publicMethods) {
-                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList, metadataTransformer, finalFile);
+                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList, metadataTransformer, finalFile, testClassName);
                 statuses.add(status);
             }
         }
         return new GenerationSummary(statuses);
     }
 
-    private Path prepareFinalTestFile(ClassMetadata owner) throws IOException {
-        Path finalFile = resolveFinalFile(owner);
+    private Path prepareFinalTestFile(ClassMetadata owner, String testClassName) throws IOException {
+        Path finalFile = resolveFinalFile(owner, testClassName);
         Files.createDirectories(finalFile.getParent());
         if (Files.notExists(finalFile)) {
-            Files.writeString(finalFile, createSkeleton(owner.getPackageName()), StandardCharsets.UTF_8,
+            Files.writeString(finalFile, createSkeleton(owner.getPackageName(), testClassName), StandardCharsets.UTF_8,
                     StandardOpenOption.CREATE_NEW);
         }
         return finalFile;
     }
 
-    private Path resolveFinalFile(ClassMetadata owner) {
+    private Path resolveFinalFile(ClassMetadata owner, String testClassName) {
         String packageName = owner.getPackageName();
         if (packageName == null || packageName.isBlank()) {
-            return testSourcesRoot.resolve("FinalGeneratedTest.java");
+            return testSourcesRoot.resolve(testClassName + ".java");
         }
         Path packagePath = testSourcesRoot;
         for (String segment : packageName.split("\\.")) {
@@ -148,7 +149,15 @@ public class DiffMethodGenerationRunner {
                 packagePath = packagePath.resolve(segment);
             }
         }
-        return packagePath.resolve("FinalGeneratedTest.java");
+        return packagePath.resolve(testClassName + ".java");
+    }
+
+    private String resolveTestClassName(ClassMetadata owner) {
+        String baseName = owner.getClassName();
+        if (baseName == null || baseName.isBlank()) {
+            return "GeneratedTest";
+        }
+        return baseName.endsWith("Test") ? baseName : baseName + "Test";
     }
 
     private MethodGenerationStatus processMethod(ClassMetadata owner,
@@ -158,7 +167,8 @@ public class DiffMethodGenerationRunner {
                                                  Map<String, ClassMetadata> metadataIndex,
                                                  List<ClassMetadata> discoveredList,
                                                  MetadataTransformer metadataTransformer,
-                                                 Path finalFile) throws IOException {
+                                                 Path finalFile,
+                                                 String testClassName) throws IOException {
         List<String> feedback = new ArrayList<>();
         int iterations = 0;
         boolean compiled = false;
@@ -170,7 +180,7 @@ public class DiffMethodGenerationRunner {
             iterations++;
             final int attempt = iterations;
             final int totalAttempts = maxRetries + 1;
-            String prompt = buildPrompt(classContext, owner, method, feedback, metadataIndex, discoveredList);
+            String prompt = buildPrompt(classContext, owner, method, feedback, metadataIndex, discoveredList, testClassName);
             LOGGER.info(() -> String.format(Locale.ENGLISH,
                     "Формирование diff-method запроса (%d/%d) для %s#%s",
                     attempt, totalAttempts, owner.getQualifiedName(), method.getName()));
@@ -191,11 +201,11 @@ public class DiffMethodGenerationRunner {
             }
             String currentSource = Files.exists(finalFile)
                     ? Files.readString(finalFile)
-                    : createSkeleton(owner.getPackageName());
+                    : createSkeleton(owner.getPackageName(), testClassName);
             currentSource = ensurePackageDeclaration(currentSource, owner.getPackageName());
-            String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method);
-            candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource);
-            GeneratedTestClass candidateClass = new GeneratedTestClass(owner.getPackageName(), "FinalGeneratedTest", candidateSource);
+            String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method, testClassName, finalFile);
+            candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource, testClassName);
+            GeneratedTestClass candidateClass = new GeneratedTestClass(owner.getPackageName(), testClassName, candidateSource);
             GeneratedTestClass verifiedClass = testVerifier.verify(candidateClass, promptMetadata, previousCompilationErrors);
             candidateSource = verifiedClass.getSourceCode();
             ValidationResult validationResult = responseValidator.validate(candidateSource, promptMetadata);
@@ -228,7 +238,8 @@ public class DiffMethodGenerationRunner {
                                MethodMetadata method,
                                List<String> previousErrors,
                                Map<String, ClassMetadata> metadataIndex,
-                               List<ClassMetadata> discoveredList) {
+                               List<ClassMetadata> discoveredList,
+                               String testClassName) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("Вы — помощник, который пишет модульные тесты на JUnit 5.\n");
         prompt.append("class_api_context = ").append(classContext).append('\n');
@@ -238,14 +249,18 @@ public class DiffMethodGenerationRunner {
             prompt.append("available_api_signatures:\n");
             prompt.append(apiReference);
         }
-        prompt.append("Сгенерируй ровно один тестовый метод внутри класса FinalGeneratedTest.\n");
+        prompt.append(String.format(Locale.ENGLISH,
+                "Сгенерируй ровно один тестовый метод внутри класса %s.\n",
+                testClassName));
         prompt.append("Требования:\n");
         prompt.append("- Используй аннотацию @org.junit.jupiter.api.Test.\n");
         prompt.append("- В начале ответа перечисли необходимые import-операторы (каждый в формате 'import ...;'), затем оставь пустую строку и приведи ровно один тестовый метод.\n");
         prompt.append("- Пользуйся только типами и методами из available_api_signatures и стандартной библиотеки Java.\n");
         prompt.append("- Используй явные типы в объявлениях переменных, не применяй ключевое слово var.\n");
         prompt.append("- Используй короткие имена типов с необходимыми import-операторами; не оставляй fully-qualified имена в коде.\n");
-        prompt.append("- Не добавляй объявление класса FinalGeneratedTest и не используй package.\n");
+        prompt.append(String.format(Locale.ENGLISH,
+                "- Не добавляй объявление класса %s и не используй package.\n",
+                testClassName));
         prompt.append("- Не используй Mockito, AssertJ, Hamcrest и другие внешние фреймворки.\n");
         prompt.append("- Для проверок используй конструкции вида if (... ) { throw new AssertionError(\"описание\"); }.\n");
         prompt.append("- Чтобы подменить зависимости, создавай простые анонимные реализации или реальные объекты с доступными конструкторами.\n");
@@ -468,7 +483,11 @@ public class DiffMethodGenerationRunner {
         return count;
     }
 
-    private String mergeMethodIntoSource(String methodSource, String currentSource, MethodMetadata method) {
+    private String mergeMethodIntoSource(String methodSource,
+                                         String currentSource,
+                                         MethodMetadata method,
+                                         String testClassName,
+                                         Path finalFile) {
         int insertionPoint;
         String sanitized = methodSource.strip();
         String withoutExisting = currentSource;
@@ -481,7 +500,10 @@ public class DiffMethodGenerationRunner {
         }
         insertionPoint = withoutExisting.lastIndexOf('}');
         if (insertionPoint < 0) {
-            throw new IllegalStateException("FinalGeneratedTest.java is malformed: missing class terminator");
+            String fileName = finalFile.getFileName() == null
+                    ? testClassName + ".java"
+                    : finalFile.getFileName().toString();
+            throw new IllegalStateException(fileName + " is malformed: missing class terminator");
         }
         String indented = indentMethod(sanitized);
         StringBuilder updated = new StringBuilder(withoutExisting);
@@ -618,7 +640,7 @@ public class DiffMethodGenerationRunner {
         return true;
     }
 
-    private String createSkeleton(String packageName) {
+    private String createSkeleton(String packageName, String testClassName) {
         StringBuilder builder = new StringBuilder();
         if (packageName != null && !packageName.isBlank()) {
             builder.append("package ")
@@ -630,7 +652,9 @@ public class DiffMethodGenerationRunner {
         builder.append("import org.junit.jupiter.api.Test;")
                 .append(System.lineSeparator())
                 .append(System.lineSeparator())
-                .append("public class FinalGeneratedTest {")
+                .append("public class ")
+                .append(testClassName)
+                .append(" {")
                 .append(System.lineSeparator())
                 .append(System.lineSeparator())
                 .append('}')
@@ -654,14 +678,14 @@ public class DiffMethodGenerationRunner {
         return "package " + packageName + ';' + System.lineSeparator() + System.lineSeparator() + source;
     }
 
-    private String mergeImportsIntoSource(Collection<String> newImports, String source) {
+    private String mergeImportsIntoSource(Collection<String> newImports, String source, String testClassName) {
         if (source == null || source.isEmpty()) {
             return source;
         }
         String[] lines = source.split("\\R", -1);
         int classLineIndex = -1;
         for (int i = 0; i < lines.length; i++) {
-            if (lines[i].contains("class FinalGeneratedTest")) {
+            if (lines[i].contains("class " + testClassName)) {
                 classLineIndex = i;
                 break;
             }

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -18,10 +18,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -49,7 +51,7 @@ public class DiffMethodGenerationRunner {
     private final Map<String, Object> requestOptions;
     private final JavaCompiler compiler;
     private final Path workingDirectory;
-    private final Path candidateFile;
+    private final Path testSourcesRoot;
     private final Path finalFile;
     private long lastRequestAtNanos;
 
@@ -70,8 +72,8 @@ public class DiffMethodGenerationRunner {
             throw new IllegalStateException("Java compiler is not available. Ensure a JDK is installed.");
         }
         this.workingDirectory = projectRoot.resolve("build").resolve("diff-method");
-        this.candidateFile = workingDirectory.resolve("GeneratedTestCandidate.java");
-        this.finalFile = workingDirectory.resolve("FinalGeneratedTest.java");
+        this.testSourcesRoot = projectRoot.resolve(Paths.get("src", "test", "java"));
+        this.finalFile = testSourcesRoot.resolve("FinalGeneratedTest.java");
         this.lastRequestAtNanos = -1L;
     }
 
@@ -79,6 +81,10 @@ public class DiffMethodGenerationRunner {
         Objects.requireNonNull(targets, "targets");
         Objects.requireNonNull(discovered, "discovered");
         Files.createDirectories(workingDirectory);
+        Files.createDirectories(testSourcesRoot);
+        if (Files.notExists(finalFile)) {
+            Files.writeString(finalFile, createSkeleton(), StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+        }
         List<Path> supportSources = ensureSupportSources();
         Map<String, ClassMetadata> metadataIndex = discovered.stream()
                 .collect(Collectors.toMap(ClassMetadata::getQualifiedName, Function.identity(), (left, right) -> left, LinkedHashMap::new));
@@ -121,6 +127,7 @@ public class DiffMethodGenerationRunner {
         int iterations = 0;
         boolean compiled = false;
         List<String> lastErrors = List.of();
+        List<Path> projectSources = collectCompilationSources(owner, metadataIndex);
         while (iterations <= maxRetries) {
             iterations++;
             final int attempt = iterations;
@@ -141,11 +148,11 @@ public class DiffMethodGenerationRunner {
             String currentSource = Files.exists(finalFile)
                     ? Files.readString(finalFile)
                     : createSkeleton();
-            String candidateSource = mergeMethodIntoSource(methodSource.get(), currentSource);
-            Files.writeString(candidateFile, candidateSource, StandardCharsets.UTF_8);
-            CompilationResult compilation = compileCandidate(candidateFile, supportSources);
+            String candidateSource = mergeMethodIntoSource(methodSource.get(), currentSource, method.getName());
+            Files.createDirectories(finalFile.getParent());
+            Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+            CompilationResult compilation = compileCandidate(finalFile, supportSources, projectSources);
             if (compilation.success()) {
-                Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8);
                 compiled = true;
                 lastErrors = List.of();
                 break;
@@ -380,36 +387,20 @@ public class DiffMethodGenerationRunner {
         return count;
     }
 
-    private String mergeMethodIntoSource(String methodSource, String currentSource) {
-        if (containsMethod(currentSource, methodSource)) {
-            return currentSource;
-        }
-        int insertionPoint = currentSource.lastIndexOf('}');
+    private String mergeMethodIntoSource(String methodSource, String currentSource, String methodName) {
+        int insertionPoint;
+        String sanitized = methodSource.strip();
+        String withoutExisting = removeExistingMethod(currentSource, methodName);
+        insertionPoint = withoutExisting.lastIndexOf('}');
         if (insertionPoint < 0) {
             throw new IllegalStateException("FinalGeneratedTest.java is malformed: missing class terminator");
         }
-        String indented = indentMethod(methodSource.strip());
-        StringBuilder updated = new StringBuilder(currentSource);
+        String indented = indentMethod(sanitized);
+        StringBuilder updated = new StringBuilder(withoutExisting);
         String separator = System.lineSeparator();
         String insertion = separator + indented + separator;
         updated.insert(insertionPoint, insertion);
         return updated.toString();
-    }
-
-    private boolean containsMethod(String source, String methodSource) {
-        String signature = extractSignatureLine(methodSource);
-        return !signature.isEmpty() && source.contains(signature);
-    }
-
-    private String extractSignatureLine(String methodSource) {
-        for (String line : methodSource.split("\\R")) {
-            String trimmed = line.trim();
-            if (trimmed.isEmpty() || trimmed.startsWith("@")) {
-                continue;
-            }
-            return trimmed;
-        }
-        return "";
     }
 
     private String indentMethod(String methodSource) {
@@ -421,6 +412,56 @@ public class DiffMethodGenerationRunner {
                 builder.append(System.lineSeparator());
             }
         }
+        return builder.toString();
+    }
+
+    private String removeExistingMethod(String source, String methodName) {
+        Optional<String> existingBlock = extractMethodBlock(source, methodName);
+        if (existingBlock.isEmpty()) {
+            return source;
+        }
+        String block = existingBlock.get();
+        int index = source.indexOf(block);
+        if (index < 0) {
+            return source;
+        }
+        int removalStart = index;
+        while (removalStart > 0) {
+            char previous = source.charAt(removalStart - 1);
+            if (previous == '\n') {
+                removalStart--;
+                if (removalStart > 0 && source.charAt(removalStart - 1) == '\r') {
+                    removalStart--;
+                }
+                break;
+            }
+            if (!Character.isWhitespace(previous)) {
+                break;
+            }
+            removalStart--;
+        }
+        int end = index + block.length();
+        while (end < source.length()) {
+            char current = source.charAt(end);
+            if (current == '\r') {
+                end++;
+                if (end < source.length() && source.charAt(end) == '\n') {
+                    end++;
+                }
+                break;
+            }
+            if (current == '\n') {
+                end++;
+                break;
+            }
+            if (!Character.isWhitespace(current)) {
+                break;
+            }
+            end++;
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(source, 0, removalStart);
+        builder.append(source.substring(end));
         return builder.toString();
     }
 
@@ -530,6 +571,44 @@ public class DiffMethodGenerationRunner {
         return sources;
     }
 
+    private List<Path> collectCompilationSources(ClassMetadata owner, Map<String, ClassMetadata> metadataIndex) {
+        LinkedHashSet<Path> sources = new LinkedHashSet<>();
+        LinkedHashSet<String> seen = new LinkedHashSet<>();
+        Deque<ClassMetadata> queue = new ArrayDeque<>();
+        queue.add(owner);
+        seen.add(owner.getQualifiedName());
+        seen.add(owner.getClassName());
+        while (!queue.isEmpty()) {
+            ClassMetadata current = queue.removeFirst();
+            addSourcePath(sources, current.getSourcePath());
+            for (String dependency : current.getDependencies()) {
+                if (dependency == null || dependency.isBlank()) {
+                    continue;
+                }
+                ClassMetadata dependencyMetadata = metadataIndex.get(dependency);
+                if (dependencyMetadata == null) {
+                    continue;
+                }
+                String qualified = dependencyMetadata.getQualifiedName();
+                if (seen.add(qualified)) {
+                    queue.add(dependencyMetadata);
+                }
+                seen.add(dependencyMetadata.getClassName());
+            }
+        }
+        return new ArrayList<>(sources);
+    }
+
+    private void addSourcePath(Set<Path> collector, Path path) {
+        if (path == null) {
+            return;
+        }
+        Path absolute = path.toAbsolutePath().normalize();
+        if (Files.exists(absolute)) {
+            collector.add(absolute);
+        }
+    }
+
     private Path writeStubSource(Path file, String content) throws IOException {
         Files.createDirectories(file.getParent());
         Files.writeString(file, content, StandardCharsets.UTF_8,
@@ -537,11 +616,12 @@ public class DiffMethodGenerationRunner {
         return file;
     }
 
-    private CompilationResult compileCandidate(Path sourceFile, List<Path> supportSources) throws IOException {
+    private CompilationResult compileCandidate(Path sourceFile, List<Path> supportSources, List<Path> projectSources) throws IOException {
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         List<String> options = buildCompilerOptions();
         try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
             List<Path> compilationPaths = new ArrayList<>(supportSources);
+            compilationPaths.addAll(projectSources);
             compilationPaths.add(sourceFile);
             Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(
                     compilationPaths.stream().map(Path::toFile).collect(Collectors.toList()));

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -1,0 +1,545 @@
+package com.example.tests.generator.diff;
+
+import com.example.agent.providers.LLMClient;
+import com.example.tests.generator.model.ClassMetadata;
+import com.example.tests.generator.model.MethodMetadata;
+import com.example.tests.generator.model.MethodMetadata.Parameter;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * Executes the per-method diff generation workflow when the --diff-method flag is active.
+ */
+public class DiffMethodGenerationRunner {
+
+    private static final Logger LOGGER = Logger.getLogger(DiffMethodGenerationRunner.class.getName());
+
+    private final Path projectRoot;
+    private final LLMClient llmClient;
+    private final int maxRetries;
+    private final Duration requestDelay;
+    private final Map<String, Object> requestOptions;
+    private final JavaCompiler compiler;
+    private final Path workingDirectory;
+    private final Path candidateFile;
+    private final Path finalFile;
+    private long lastRequestAtNanos;
+
+    public DiffMethodGenerationRunner(Path projectRoot,
+                                      LLMClient llmClient,
+                                      int maxRetries,
+                                      Duration requestDelay,
+                                      Map<String, Object> requestOptions) {
+        this.projectRoot = Objects.requireNonNull(projectRoot, "projectRoot");
+        this.llmClient = Objects.requireNonNull(llmClient, "llmClient");
+        this.maxRetries = Math.max(0, maxRetries);
+        this.requestDelay = requestDelay == null ? Duration.ZERO : requestDelay;
+        this.requestOptions = requestOptions == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new HashMap<>(requestOptions));
+        this.compiler = ToolProvider.getSystemJavaCompiler();
+        if (this.compiler == null) {
+            throw new IllegalStateException("Java compiler is not available. Ensure a JDK is installed.");
+        }
+        this.workingDirectory = projectRoot.resolve("build").resolve("diff-method");
+        this.candidateFile = workingDirectory.resolve("GeneratedTestCandidate.java");
+        this.finalFile = workingDirectory.resolve("FinalGeneratedTest.java");
+        this.lastRequestAtNanos = -1L;
+    }
+
+    public GenerationSummary execute(List<ClassMetadata> targets, List<ClassMetadata> discovered) throws IOException {
+        Objects.requireNonNull(targets, "targets");
+        Objects.requireNonNull(discovered, "discovered");
+        Files.createDirectories(workingDirectory);
+        List<MethodGenerationStatus> statuses = new ArrayList<>();
+        for (ClassMetadata target : targets) {
+            List<MethodMetadata> publicMethods = target.getMethods().stream()
+                    .filter(MethodMetadata::isPublic)
+                    .collect(Collectors.toList());
+            if (publicMethods.isEmpty()) {
+                LOGGER.info(() -> String.format(Locale.ENGLISH,
+                        "Класс %s не содержит публичных методов для diff-генерации",
+                        target.getQualifiedName()));
+                continue;
+            }
+            String classContext = buildClassContext(target, discovered);
+            LOGGER.info(() -> "class_api_context для " + target.getQualifiedName() + ":\n" + classContext);
+            for (MethodMetadata method : publicMethods) {
+                MethodGenerationStatus status = processMethod(target, method, classContext);
+                statuses.add(status);
+            }
+        }
+        return new GenerationSummary(statuses);
+    }
+
+    private MethodGenerationStatus processMethod(ClassMetadata owner,
+                                                 MethodMetadata method,
+                                                 String classContext) throws IOException {
+        List<String> feedback = new ArrayList<>();
+        int iterations = 0;
+        boolean compiled = false;
+        List<String> lastErrors = List.of();
+        while (iterations <= maxRetries) {
+            iterations++;
+            String prompt = buildPrompt(classContext, owner, method, feedback);
+            LOGGER.info(() -> String.format(Locale.ENGLISH,
+                    "Формирование diff-method запроса (%d/%d) для %s#%s",
+                    iterations, maxRetries + 1, owner.getQualifiedName(), method.getName()));
+            String response = sendPrompt(prompt);
+            Optional<String> methodSource = extractMethod(response, method.getName());
+            if (methodSource.isEmpty()) {
+                feedback = List.of(String.format(Locale.ENGLISH,
+                        "LLM response did not contain a test method for %s#%s",
+                        owner.getQualifiedName(), method.getName()));
+                lastErrors = feedback;
+                continue;
+            }
+            String currentSource = Files.exists(finalFile)
+                    ? Files.readString(finalFile)
+                    : createSkeleton();
+            String candidateSource = mergeMethodIntoSource(methodSource.get(), currentSource);
+            Files.writeString(candidateFile, candidateSource, StandardCharsets.UTF_8);
+            CompilationResult compilation = compileCandidate(candidateFile);
+            if (compilation.success()) {
+                Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8);
+                compiled = true;
+                lastErrors = List.of();
+                break;
+            }
+            feedback = compilation.errors();
+            lastErrors = feedback;
+        }
+        return new MethodGenerationStatus(owner.getQualifiedName(), method.getName(), compiled, iterations, lastErrors);
+    }
+
+    private String buildPrompt(String classContext,
+                               ClassMetadata owner,
+                               MethodMetadata method,
+                               List<String> previousErrors) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("Вы — помощник, который пишет модульные тесты на JUnit 5.\n");
+        prompt.append("class_api_context = ").append(classContext).append('\n');
+        prompt.append("target_method = ").append(describeMethod(owner, method)).append('\n');
+        prompt.append("Сгенерируй ровно один тестовый метод внутри класса FinalGeneratedTest.\n");
+        prompt.append("Требования:\n");
+        prompt.append("- Используй аннотацию @org.junit.jupiter.api.Test.\n");
+        prompt.append("- Не включай объявление класса, только метод.\n");
+        prompt.append("- Тест должен однозначно компилироваться.\n");
+        if (!previousErrors.isEmpty()) {
+            prompt.append("Предыдущие ошибки компиляции:\n");
+            for (String error : previousErrors) {
+                prompt.append("- ").append(error).append('\n');
+            }
+        }
+        prompt.append("Ответь только кодом метода.");
+        return prompt.toString();
+    }
+
+    private String describeMethod(ClassMetadata owner, MethodMetadata method) {
+        String parameters = method.getParameters().stream()
+                .map(Parameter::toString)
+                .collect(Collectors.joining(", "));
+        String ownerName = owner.getClassName();
+        if (parameters.isEmpty()) {
+            parameters = "";
+        }
+        if (method.isConstructor()) {
+            return ownerName + '(' + parameters + ')';
+        }
+        String qualifier = method.isStatic() ? "static " : "";
+        return qualifier + method.getReturnType() + ' ' + ownerName + '.' + method.getName() + '(' + parameters + ')';
+    }
+
+    private Optional<String> extractMethod(String response, String methodName) {
+        if (response == null || response.isBlank()) {
+            return Optional.empty();
+        }
+        String code = extractCodeBlock(response).trim();
+        if (code.isEmpty() || !code.contains(methodName + "(")) {
+            return Optional.empty();
+        }
+        if (!code.contains("class ")) {
+            return Optional.of(code.trim());
+        }
+        return extractMethodBlock(code, methodName).map(String::trim);
+    }
+
+    private String extractCodeBlock(String response) {
+        int fenceStart = response.indexOf("```");
+        if (fenceStart < 0) {
+            return response;
+        }
+        int contentStart = fenceStart + 3;
+        if (contentStart < response.length() && response.charAt(contentStart) == 'j') {
+            int newline = response.indexOf('\n', contentStart);
+            if (newline > contentStart) {
+                contentStart = newline + 1;
+            }
+        }
+        int fenceEnd = response.indexOf("```", contentStart);
+        if (fenceEnd < 0) {
+            return response.substring(contentStart);
+        }
+        return response.substring(contentStart, fenceEnd);
+    }
+
+    private Optional<String> extractMethodBlock(String source, String methodName) {
+        String[] lines = source.split("\\R");
+        StringBuilder builder = new StringBuilder();
+        boolean capturing = false;
+        int braceBalance = 0;
+        boolean seenBody = false;
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            if (!capturing && isMethodDeclarationLine(line, methodName)) {
+                int start = i;
+                while (start > 0 && lines[start - 1].trim().startsWith("@")) {
+                    start--;
+                }
+                for (int j = start; j <= i; j++) {
+                    builder.append(lines[j]).append(System.lineSeparator());
+                    braceBalance += countOccurrences(lines[j], '{');
+                    braceBalance -= countOccurrences(lines[j], '}');
+                    if (lines[j].contains("{")) {
+                        seenBody = true;
+                    }
+                }
+                capturing = true;
+                continue;
+            }
+            if (capturing) {
+                builder.append(line).append(System.lineSeparator());
+                braceBalance += countOccurrences(line, '{');
+                braceBalance -= countOccurrences(line, '}');
+                if (line.contains("{")) {
+                    seenBody = true;
+                }
+                if (seenBody && braceBalance <= 0) {
+                    return Optional.of(builder.toString().stripTrailing());
+                }
+            }
+        }
+        if (capturing) {
+            return Optional.of(builder.toString().stripTrailing());
+        }
+        return Optional.empty();
+    }
+
+    private boolean isMethodDeclarationLine(String line, String methodName) {
+        String trimmed = line.trim();
+        if (trimmed.startsWith("//") || trimmed.contains(";")) {
+            return false;
+        }
+        int nameIndex = trimmed.indexOf(methodName + "(");
+        if (nameIndex < 0) {
+            return false;
+        }
+        return nameIndex + methodName.length() + 1 < trimmed.length();
+    }
+
+    private int countOccurrences(String value, char target) {
+        int count = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == target) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private String mergeMethodIntoSource(String methodSource, String currentSource) {
+        if (containsMethod(currentSource, methodSource)) {
+            return currentSource;
+        }
+        int insertionPoint = currentSource.lastIndexOf('}');
+        if (insertionPoint < 0) {
+            throw new IllegalStateException("FinalGeneratedTest.java is malformed: missing class terminator");
+        }
+        String indented = indentMethod(methodSource.strip());
+        StringBuilder updated = new StringBuilder(currentSource);
+        String separator = System.lineSeparator();
+        String insertion = separator + indented + separator;
+        updated.insert(insertionPoint, insertion);
+        return updated.toString();
+    }
+
+    private boolean containsMethod(String source, String methodSource) {
+        String signature = extractSignatureLine(methodSource);
+        return !signature.isEmpty() && source.contains(signature);
+    }
+
+    private String extractSignatureLine(String methodSource) {
+        for (String line : methodSource.split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("@")) {
+                continue;
+            }
+            return trimmed;
+        }
+        return "";
+    }
+
+    private String indentMethod(String methodSource) {
+        String[] lines = methodSource.split("\\R");
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            builder.append("    ").append(lines[i]);
+            if (i < lines.length - 1) {
+                builder.append(System.lineSeparator());
+            }
+        }
+        return builder.toString();
+    }
+
+    private String createSkeleton() {
+        return "import org.junit.jupiter.api.Test;" + System.lineSeparator()
+                + System.lineSeparator()
+                + "public class FinalGeneratedTest {" + System.lineSeparator()
+                + System.lineSeparator()
+                + "}" + System.lineSeparator();
+    }
+
+    private CompilationResult compileCandidate(Path sourceFile) throws IOException {
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        List<String> options = buildCompilerOptions();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+            Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(List.of(sourceFile.toFile()));
+            JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, options, null, compilationUnits);
+            boolean success = Boolean.TRUE.equals(task.call());
+            List<String> errors = diagnostics.getDiagnostics().stream()
+                    .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                    .map(diagnostic -> formatDiagnostic(diagnostic, sourceFile))
+                    .collect(Collectors.toList());
+            if (!errors.isEmpty()) {
+                success = false;
+            }
+            return new CompilationResult(success, errors);
+        }
+    }
+
+    private List<String> buildCompilerOptions() {
+        String classpath = System.getProperty("java.class.path", "");
+        List<String> options = new ArrayList<>();
+        options.add("-proc:none");
+        if (!classpath.isBlank()) {
+            options.add("-classpath");
+            options.add(classpath);
+        }
+        return options;
+    }
+
+    private String formatDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic, Path sourceFile) {
+        String sourceName;
+        if (diagnostic.getSource() != null) {
+            sourceName = Paths.get(diagnostic.getSource().toUri()).getFileName().toString();
+        } else {
+            sourceName = sourceFile.getFileName().toString();
+        }
+        return String.format(Locale.ENGLISH, "%s:%d:%d %s",
+                sourceName,
+                diagnostic.getLineNumber(),
+                diagnostic.getColumnNumber(),
+                diagnostic.getMessage(Locale.ENGLISH));
+    }
+
+    private String buildClassContext(ClassMetadata target, List<ClassMetadata> discovered) {
+        String indent = "  ";
+        StringBuilder builder = new StringBuilder();
+        builder.append('{').append(System.lineSeparator());
+        builder.append(indent).append("\"qualified_name\": \"")
+                .append(escapeJson(target.getQualifiedName())).append("\",").append(System.lineSeparator());
+        builder.append(indent).append("\"package\": \"")
+                .append(escapeJson(target.getPackageName())).append("\",").append(System.lineSeparator());
+        builder.append(indent).append("\"imports\": ")
+                .append(toJsonArray(target.getImports())).append(',').append(System.lineSeparator());
+        builder.append(indent).append("\"dependencies\": ")
+                .append(toJsonArray(target.getDependencies())).append(',').append(System.lineSeparator());
+        builder.append(indent).append("\"inner_types\": ")
+                .append(toJsonArray(resolveInnerTypes(target, discovered))).append(',').append(System.lineSeparator());
+        builder.append(indent).append("\"methods\": [").append(System.lineSeparator());
+        List<MethodMetadata> methods = target.getMethods().stream()
+                .filter(MethodMetadata::isPublic)
+                .collect(Collectors.toList());
+        for (int i = 0; i < methods.size(); i++) {
+            MethodMetadata method = methods.get(i);
+            builder.append(indent).append(indent).append('{').append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"name\": \"")
+                    .append(escapeJson(method.getName())).append("\",").append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"return_type\": \"")
+                    .append(escapeJson(method.getReturnType())).append("\",").append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"constructor\": ")
+                    .append(method.isConstructor()).append(',').append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"static\": ")
+                    .append(method.isStatic()).append(',').append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"annotations\": ")
+                    .append(toJsonArray(method.getAnnotations())).append(',').append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"parameters\": [");
+            List<Parameter> parameters = method.getParameters();
+            if (!parameters.isEmpty()) {
+                builder.append(System.lineSeparator());
+                for (int j = 0; j < parameters.size(); j++) {
+                    Parameter parameter = parameters.get(j);
+                    builder.append(indent).append(indent).append(indent).append(indent).append('{')
+                            .append("\"type\": \"").append(escapeJson(parameter.getType())).append("\",")
+                            .append(" \"name\": \"").append(escapeJson(parameter.getName())).append("\"}");
+                    if (j < parameters.size() - 1) {
+                        builder.append(',');
+                    }
+                    builder.append(System.lineSeparator());
+                }
+                builder.append(indent).append(indent).append(indent).append(']');
+            } else {
+                builder.append(']');
+            }
+            builder.append(',').append(System.lineSeparator());
+            builder.append(indent).append(indent).append(indent).append("\"signature\": \"")
+                    .append(escapeJson(describeMethod(target, method))).append("\"").append(System.lineSeparator());
+            builder.append(indent).append(indent).append('}');
+            if (i < methods.size() - 1) {
+                builder.append(',');
+            }
+            builder.append(System.lineSeparator());
+        }
+        builder.append(indent).append(']').append(System.lineSeparator());
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private List<String> resolveInnerTypes(ClassMetadata target, List<ClassMetadata> discovered) {
+        String prefix = target.getClassName() + '.';
+        return discovered.stream()
+                .map(ClassMetadata::getClassName)
+                .filter(name -> name.startsWith(prefix))
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private String toJsonArray(Collection<String> values) {
+        if (values == null || values.isEmpty()) {
+            return "[]";
+        }
+        Set<String> unique = values.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (unique.isEmpty()) {
+            return "[]";
+        }
+        List<String> sorted = new ArrayList<>(unique);
+        sorted.sort(Comparator.naturalOrder());
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < sorted.size(); i++) {
+            builder.append('"').append(escapeJson(sorted.get(i))).append('"');
+            if (i < sorted.size() - 1) {
+                builder.append(',').append(' ');
+            }
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '\\' || ch == '"') {
+                escaped.append('\\');
+            }
+            escaped.append(ch);
+        }
+        return escaped.toString();
+    }
+
+    private String sendPrompt(String prompt) {
+        applyRequestDelay();
+        String response = llmClient.sendPrompt(prompt, requestOptions);
+        lastRequestAtNanos = System.nanoTime();
+        return response;
+    }
+
+    private void applyRequestDelay() {
+        if (requestDelay.isZero() || lastRequestAtNanos < 0) {
+            return;
+        }
+        long elapsed = System.nanoTime() - lastRequestAtNanos;
+        long required = requestDelay.toNanos();
+        long remaining = required - elapsed;
+        if (remaining <= 0) {
+            return;
+        }
+        long millis = remaining / 1_000_000L;
+        int nanos = (int) (remaining % 1_000_000L);
+        try {
+            Thread.sleep(millis, nanos);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting between prompts", ex);
+        }
+    }
+
+    private record CompilationResult(boolean success, List<String> errors) {
+    }
+
+    public record MethodGenerationStatus(String className,
+                                         String methodName,
+                                         boolean compiled,
+                                         int iterations,
+                                         List<String> lastErrors) {
+        public MethodGenerationStatus {
+            lastErrors = lastErrors == null ? List.of() : List.copyOf(lastErrors);
+        }
+    }
+
+    public record GenerationSummary(List<MethodGenerationStatus> methods) {
+        public GenerationSummary {
+            methods = methods == null ? List.of() : List.copyOf(methods);
+        }
+
+        public void printSummary() {
+            if (methods.isEmpty()) {
+                System.out.println("Дифф-режим: нет публичных методов для обработки.");
+                return;
+            }
+            System.out.println("Дифф-режим: результаты генерации по методам:");
+            for (MethodGenerationStatus status : methods) {
+                String outcome = status.compiled() ? "успех" : "ошибка";
+                System.out.printf(Locale.ENGLISH, "- %s#%s: %s после %d попыток%n",
+                        status.className(), status.methodName(), outcome, status.iterations());
+                if (!status.lastErrors().isEmpty()) {
+                    for (String error : status.lastErrors()) {
+                        System.out.println("    * " + error);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -324,12 +324,48 @@ public class DiffMethodGenerationRunner {
             }
         }
 
+        Set<String> documentedDependencies = methodDependencies == null
+                ? Set.of()
+                : methodDependencies.documentedQualifiedNames();
+
+        if (methodDependencies != null && !methodDependencies.dependencyDocumentation().isEmpty()) {
+            if (builder.length() > 0) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("- Зависимости целевого метода:").append(System.lineSeparator());
+            for (MethodDependencyInfo.DependencyDocumentation doc : methodDependencies.dependencyDocumentation()) {
+                ClassMetadata dependencyMetadata = doc.metadata();
+                builder.append("  * ").append(dependencyMetadata.getQualifiedName()).append(System.lineSeparator());
+                List<String> constructors = doc.constructors();
+                if (!constructors.isEmpty()) {
+                    builder.append("    Конструкторы:").append(System.lineSeparator());
+                    for (String constructor : constructors) {
+                        builder.append("      - ").append(constructor).append(System.lineSeparator());
+                    }
+                }
+                List<String> methods = doc.methods();
+                if (!methods.isEmpty()) {
+                    builder.append("    Методы:").append(System.lineSeparator());
+                    for (String method : methods) {
+                        builder.append("      - ").append(method).append(System.lineSeparator());
+                    }
+                }
+                if (dependencyMetadata.isEnumType() && !dependencyMetadata.getEnumConstants().isEmpty()) {
+                    builder.append("    Enum-константы:").append(System.lineSeparator());
+                    for (String constant : dependencyMetadata.getEnumConstants()) {
+                        builder.append("      - ").append(constant).append(System.lineSeparator());
+                    }
+                }
+            }
+        }
+
         Set<String> dependencies = new LinkedHashSet<>(owner.getDependencies());
         if (methodDependencies != null) {
             methodDependencies.domainTypes().stream()
                     .map(ClassMetadata::getQualifiedName)
                     .forEach(dependencies::add);
         }
+        dependencies.removeAll(documentedDependencies);
         if (!dependencies.isEmpty()) {
             if (builder.length() > 0) {
                 builder.append(System.lineSeparator());
@@ -394,14 +430,23 @@ public class DiffMethodGenerationRunner {
 
         private final List<ClassMetadata> domainTypes;
         private final List<String> standardTypes;
+        private final List<DependencyDocumentation> documentation;
+        private final Set<String> documentedQualifiedNames;
 
-        private MethodDependencyInfo(List<ClassMetadata> domainTypes, List<String> standardTypes) {
+        private MethodDependencyInfo(List<ClassMetadata> domainTypes,
+                                     List<String> standardTypes,
+                                     List<DependencyDocumentation> documentation) {
             this.domainTypes = Collections.unmodifiableList(new ArrayList<>(domainTypes));
             this.standardTypes = Collections.unmodifiableList(new ArrayList<>(standardTypes));
+            this.documentation = Collections.unmodifiableList(new ArrayList<>(documentation));
+            Set<String> qualifiedNames = documentation.stream()
+                    .map(doc -> doc.metadata.getQualifiedName())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            this.documentedQualifiedNames = Collections.unmodifiableSet(qualifiedNames);
         }
 
         static MethodDependencyInfo empty() {
-            return new MethodDependencyInfo(List.of(), List.of());
+            return new MethodDependencyInfo(List.of(), List.of(), List.of());
         }
 
         static MethodDependencyInfo from(MethodDependencyGraph graph,
@@ -412,22 +457,24 @@ public class DiffMethodGenerationRunner {
             }
             LinkedHashSet<ClassMetadata> domain = new LinkedHashSet<>();
             LinkedHashSet<String> standard = new LinkedHashSet<>();
+            LinkedHashMap<ClassMetadata, DependencyDocumentation> docs = new LinkedHashMap<>();
             String ownerQualifiedName = owner.getQualifiedName();
             String ownerPackage = owner.getPackageName();
 
             for (MethodParameter parameter : graph.getParameters()) {
-                registerType(parameter.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                registerType(parameter.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
             }
             for (DependencyNode dependency : graph.getDependencies()) {
-                traverseDependency(dependency, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                processDependency(dependency, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
             }
             for (MethodInvocation invocation : graph.getUnattachedInvocations()) {
                 for (InvocationArgument argument : invocation.getArguments()) {
-                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
+                    registerExpressionTypes(argument.getExpression(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
                 }
             }
 
-            return new MethodDependencyInfo(new ArrayList<>(domain), new ArrayList<>(standard));
+            return new MethodDependencyInfo(new ArrayList<>(domain), new ArrayList<>(standard), new ArrayList<>(docs.values()));
         }
 
         List<ClassMetadata> domainTypes() {
@@ -438,39 +485,61 @@ public class DiffMethodGenerationRunner {
             return standardTypes;
         }
 
-        private static void traverseDependency(DependencyNode node,
-                                               String ownerPackage,
-                                               String ownerQualifiedName,
-                                               MetadataTransformer metadataTransformer,
-                                               Set<ClassMetadata> domain,
-                                               Set<String> standard) {
+        List<DependencyDocumentation> dependencyDocumentation() {
+            return documentation;
+        }
+
+        Set<String> documentedQualifiedNames() {
+            return documentedQualifiedNames;
+        }
+
+        private static void processDependency(DependencyNode node,
+                                              String ownerPackage,
+                                              String ownerQualifiedName,
+                                              MetadataTransformer metadataTransformer,
+                                              Set<ClassMetadata> domain,
+                                              Set<String> standard,
+                                              Map<ClassMetadata, DependencyDocumentation> docs) {
             if (node == null) {
                 return;
             }
-            registerType(node.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
-            registerType(node.getDeclaredType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+            Optional<ClassMetadata> typeMetadata = registerType(node.getType(), ownerPackage, ownerQualifiedName,
+                    metadataTransformer, domain, standard, docs);
+            registerType(node.getDeclaredType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
+
+            typeMetadata.ifPresent(metadata -> docs.computeIfAbsent(metadata, DependencyDocumentation::new)
+                    .recordConstructor(metadata, node.getConstructorArguments().size()));
+
             for (InvocationArgument argument : node.getConstructorArguments()) {
-                registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
+                registerExpressionTypes(argument.getExpression(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
             }
+
             for (MethodInvocation invocation : node.getMethodInvocations()) {
                 for (InvocationArgument argument : invocation.getArguments()) {
-                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                    registerType(argument.getType(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
+                    registerExpressionTypes(argument.getExpression(), ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
                 }
+                typeMetadata.ifPresent(metadata -> docs.computeIfAbsent(metadata, DependencyDocumentation::new)
+                        .recordMethod(metadata, invocation));
             }
+
             for (DependencyNode child : node.getDependencies()) {
-                traverseDependency(child, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard);
+                processDependency(child, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
             }
         }
 
-        private static void registerType(String rawType,
-                                         String ownerPackage,
-                                         String ownerQualifiedName,
-                                         MetadataTransformer metadataTransformer,
-                                         Set<ClassMetadata> domain,
-                                         Set<String> standard) {
+        private static Optional<ClassMetadata> registerType(String rawType,
+                                                            String ownerPackage,
+                                                            String ownerQualifiedName,
+                                                            MetadataTransformer metadataTransformer,
+                                                            Set<ClassMetadata> domain,
+                                                            Set<String> standard,
+                                                            Map<ClassMetadata, DependencyDocumentation> docs) {
             if (rawType == null || rawType.isBlank()) {
-                return;
+                return Optional.empty();
             }
+            Optional<ClassMetadata> lastResolved = Optional.empty();
             for (String token : extractTypeTokens(rawType)) {
                 if (token.isBlank()) {
                     continue;
@@ -480,10 +549,31 @@ public class DiffMethodGenerationRunner {
                     ClassMetadata metadata = resolved.get();
                     if (!metadata.getQualifiedName().equals(ownerQualifiedName)) {
                         domain.add(metadata);
+                        docs.computeIfAbsent(metadata, DependencyDocumentation::new);
                     }
+                    lastResolved = Optional.of(metadata);
                     continue;
                 }
-                StandardLibraryTypeResolver.resolve(token).ifPresent(standard::add);
+                Optional<String> standardMatch = StandardLibraryTypeResolver.resolve(token);
+                standardMatch.ifPresent(standard::add);
+            }
+            return lastResolved;
+        }
+
+        private static void registerExpressionTypes(String expression,
+                                                    String ownerPackage,
+                                                    String ownerQualifiedName,
+                                                    MetadataTransformer metadataTransformer,
+                                                    Set<ClassMetadata> domain,
+                                                    Set<String> standard,
+                                                    Map<ClassMetadata, DependencyDocumentation> docs) {
+            if (expression == null || expression.isBlank()) {
+                return;
+            }
+            Matcher matcher = Pattern.compile("\\b([A-Z][A-Za-z0-9_]*(?:\\.[A-Z][A-Za-z0-9_]*)*)\\b(?=\\.)").matcher(expression);
+            while (matcher.find()) {
+                String candidate = matcher.group(1);
+                registerType(candidate, ownerPackage, ownerQualifiedName, metadataTransformer, domain, standard, docs);
             }
         }
 
@@ -527,6 +617,77 @@ public class DiffMethodGenerationRunner {
             }
             return trimmed;
         }
+
+        static final class DependencyDocumentation {
+
+            private final ClassMetadata metadata;
+            private final LinkedHashSet<String> constructors = new LinkedHashSet<>();
+            private final LinkedHashSet<String> methods = new LinkedHashSet<>();
+
+            private DependencyDocumentation(ClassMetadata metadata) {
+                this.metadata = Objects.requireNonNull(metadata, "metadata");
+            }
+
+            private void recordConstructor(ClassMetadata metadata, int argumentCount) {
+                List<MethodMetadata> constructorsMetadata = metadata.getMethods().stream()
+                        .filter(MethodMetadata::isConstructor)
+                        .filter(MethodMetadata::isPublic)
+                        .collect(Collectors.toList());
+                if (constructorsMetadata.isEmpty()) {
+                    return;
+                }
+                boolean matched = false;
+                for (MethodMetadata method : constructorsMetadata) {
+                    if (argumentCount >= 0 && method.getParameters().size() != argumentCount) {
+                        continue;
+                    }
+                    constructors.add(describeMethodForReference(metadata, method));
+                    matched = true;
+                }
+                if (!matched) {
+                    constructors.add(describeMethodForReference(metadata, constructorsMetadata.get(0)));
+                }
+            }
+
+            private void recordMethod(ClassMetadata metadata, MethodInvocation invocation) {
+                if (invocation.getName() == null || invocation.getName().isBlank()) {
+                    return;
+                }
+                List<MethodMetadata> candidates = metadata.getMethods().stream()
+                        .filter(method -> !method.isConstructor())
+                        .filter(MethodMetadata::isPublic)
+                        .filter(method -> method.getName().equals(invocation.getName()))
+                        .collect(Collectors.toList());
+                if (candidates.isEmpty()) {
+                    methods.add(metadata.getQualifiedName() + '.' + invocation.getName() + "(...)");
+                    return;
+                }
+                boolean matched = false;
+                int argumentCount = invocation.getArguments() == null ? 0 : invocation.getArguments().size();
+                for (MethodMetadata method : candidates) {
+                    if (argumentCount >= 0 && method.getParameters().size() != argumentCount) {
+                        continue;
+                    }
+                    methods.add(describeMethodForReference(metadata, method));
+                    matched = true;
+                }
+                if (!matched) {
+                    methods.add(describeMethodForReference(metadata, candidates.get(0)));
+                }
+            }
+
+            ClassMetadata metadata() {
+                return metadata;
+            }
+
+            List<String> constructors() {
+                return new ArrayList<>(constructors);
+            }
+
+            List<String> methods() {
+                return new ArrayList<>(methods);
+            }
+        }
     }
 
     private String describeMethod(ClassMetadata owner, MethodMetadata method) {
@@ -544,7 +705,7 @@ public class DiffMethodGenerationRunner {
         return qualifier + method.getReturnType() + ' ' + ownerName + '.' + method.getName() + '(' + parameters + ')';
     }
 
-    private String describeMethodForReference(ClassMetadata owner, MethodMetadata method) {
+    private static String describeMethodForReference(ClassMetadata owner, MethodMetadata method) {
         String parameters = method.getParameters().stream()
                 .map(Parameter::toString)
                 .collect(Collectors.joining(", "));

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -249,6 +249,8 @@ public class DiffMethodGenerationRunner {
         prompt.append("- Не используй Mockito, AssertJ, Hamcrest и другие внешние фреймворки.\n");
         prompt.append("- Для проверок используй конструкции вида if (... ) { throw new AssertionError(\"описание\"); }.\n");
         prompt.append("- Чтобы подменить зависимости, создавай простые анонимные реализации или реальные объекты с доступными конструкторами.\n");
+        prompt.append("- Не используй пустые лямбда-выражения вида () -> {} вместо зависимостей; всегда реализуй интерфейсы через анонимные классы.\n");
+        prompt.append("- Убедись, что тест содержит хотя бы одну проверку (assert* или явный бросок AssertionError).\n");
         prompt.append("- Создавай и используй только те типы и методы, которые перечислены в available_api_signatures.\n");
         prompt.append("- Тест должен однозначно компилироваться.\n");
         if (!previousErrors.isEmpty()) {

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -33,8 +33,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -53,6 +55,7 @@ public class DiffMethodGenerationRunner {
     private final Path workingDirectory;
     private final Path testSourcesRoot;
     private final Path finalFile;
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\bvar\\b");
     private long lastRequestAtNanos;
 
     public DiffMethodGenerationRunner(Path projectRoot,
@@ -137,18 +140,25 @@ public class DiffMethodGenerationRunner {
                     "Формирование diff-method запроса (%d/%d) для %s#%s",
                     attempt, totalAttempts, owner.getQualifiedName(), method.getName()));
             String response = sendPrompt(prompt);
-            Optional<String> methodSource = extractMethod(response, method.getName());
-            if (methodSource.isEmpty()) {
+            Optional<GeneratedSnippet> snippet = extractSnippet(response, method.getName());
+            if (snippet.isEmpty()) {
                 feedback = List.of(String.format(Locale.ENGLISH,
                         "LLM response did not contain a test method for %s#%s",
                         owner.getQualifiedName(), method.getName()));
                 lastErrors = feedback;
                 continue;
             }
+            GeneratedSnippet generatedSnippet = snippet.get();
+            if (containsVarUsage(generatedSnippet.methodSource())) {
+                feedback = List.of("Не используй ключевое слово var. Объяви тип явно.");
+                lastErrors = feedback;
+                continue;
+            }
             String currentSource = Files.exists(finalFile)
                     ? Files.readString(finalFile)
                     : createSkeleton();
-            String candidateSource = mergeMethodIntoSource(methodSource.get(), currentSource, method.getName());
+            String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method.getName());
+            candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource);
             Files.createDirectories(finalFile.getParent());
             Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
             CompilationResult compilation = compileCandidate(finalFile, supportSources, projectSources);
@@ -181,9 +191,10 @@ public class DiffMethodGenerationRunner {
         prompt.append("Сгенерируй ровно один тестовый метод внутри класса FinalGeneratedTest.\n");
         prompt.append("Требования:\n");
         prompt.append("- Используй аннотацию @org.junit.jupiter.api.Test.\n");
-        prompt.append("- Не добавляй объявление класса FinalGeneratedTest и не пиши import.\n");
+        prompt.append("- В начале ответа перечисли необходимые import-операторы (каждый в формате 'import ...;'), затем оставь пустую строку и приведи ровно один тестовый метод.\n");
         prompt.append("- Пользуйся только типами и методами из available_api_signatures и стандартной библиотеки Java.\n");
-        prompt.append("- Все упоминаемые типы указывай полностью квалифицированными именами.\n");
+        prompt.append("- Используй явные типы в объявлениях переменных, не применяй ключевое слово var.\n");
+        prompt.append("- Не добавляй объявление класса FinalGeneratedTest и не используй package.\n");
         prompt.append("- Не используй Mockito, AssertJ, Hamcrest и другие внешние фреймворки.\n");
         prompt.append("- Для проверок используй конструкции вида if (... ) { throw new AssertionError(\"описание\"); }.\n");
         prompt.append("- Чтобы подменить зависимости, создавай простые анонимные реализации или реальные объекты с доступными конструкторами.\n");
@@ -195,7 +206,7 @@ public class DiffMethodGenerationRunner {
                 prompt.append("- ").append(error).append('\n');
             }
         }
-        prompt.append("Ответь только кодом метода.");
+        prompt.append("Ответь только импортами и кодом метода.");
         return prompt.toString();
     }
 
@@ -290,7 +301,7 @@ public class DiffMethodGenerationRunner {
         return qualifier + method.getReturnType() + ' ' + ownerName + '.' + method.getName() + '(' + parameters + ')';
     }
 
-    private Optional<String> extractMethod(String response, String methodName) {
+    private Optional<GeneratedSnippet> extractSnippet(String response, String methodName) {
         if (response == null || response.isBlank()) {
             return Optional.empty();
         }
@@ -298,10 +309,27 @@ public class DiffMethodGenerationRunner {
         if (code.isEmpty() || !code.contains(methodName + "(")) {
             return Optional.empty();
         }
-        if (!code.contains("class ")) {
-            return Optional.of(code.trim());
+        List<String> imports = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        for (String line : code.split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("import ")) {
+                imports.add(trimmed.endsWith(";") ? trimmed : trimmed + ';');
+                continue;
+            }
+            builder.append(line).append(System.lineSeparator());
         }
-        return extractMethodBlock(code, methodName).map(String::trim);
+        String methodSourceCandidate = builder.toString().trim();
+        if (methodSourceCandidate.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<String> methodBlock;
+        if (!methodSourceCandidate.contains("class ")) {
+            methodBlock = Optional.of(methodSourceCandidate);
+        } else {
+            methodBlock = extractMethodBlock(methodSourceCandidate, methodName).map(String::trim);
+        }
+        return methodBlock.map(source -> new GeneratedSnippet(imports, source));
     }
 
     private String extractCodeBlock(String response) {
@@ -471,6 +499,106 @@ public class DiffMethodGenerationRunner {
                 + "public class FinalGeneratedTest {" + System.lineSeparator()
                 + System.lineSeparator()
                 + "}" + System.lineSeparator();
+    }
+
+    private String mergeImportsIntoSource(Collection<String> newImports, String source) {
+        if (source == null || source.isEmpty()) {
+            return source;
+        }
+        String[] lines = source.split("\\R", -1);
+        int classLineIndex = -1;
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].contains("class FinalGeneratedTest")) {
+                classLineIndex = i;
+                break;
+            }
+        }
+        if (classLineIndex < 0) {
+            return source;
+        }
+        Set<String> mergedImports = new TreeSet<>();
+        List<String> headerLines = new ArrayList<>();
+        for (int i = 0; i < classLineIndex; i++) {
+            String trimmed = lines[i].trim();
+            if (trimmed.startsWith("import ")) {
+                mergedImports.add(trimmed.endsWith(";") ? trimmed : trimmed + ';');
+                continue;
+            }
+            headerLines.add(lines[i]);
+        }
+        if (newImports != null) {
+            for (String importLine : newImports) {
+                if (importLine == null) {
+                    continue;
+                }
+                String trimmed = importLine.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                if (!trimmed.startsWith("import ")) {
+                    if (!trimmed.endsWith(";")) {
+                        trimmed = "import " + trimmed + ';';
+                    } else {
+                        trimmed = "import " + trimmed.substring(0, trimmed.length() - 1).trim() + ';';
+                    }
+                } else if (!trimmed.endsWith(";")) {
+                    trimmed = trimmed + ';';
+                }
+                mergedImports.add(trimmed);
+            }
+        }
+        mergedImports.add("import org.junit.jupiter.api.Test;");
+
+        while (!headerLines.isEmpty() && headerLines.get(headerLines.size() - 1).trim().isEmpty()) {
+            headerLines.remove(headerLines.size() - 1);
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (String line : headerLines) {
+            builder.append(line).append(System.lineSeparator());
+        }
+        if (!headerLines.isEmpty()) {
+            builder.append(System.lineSeparator());
+        }
+        for (String importLine : mergedImports) {
+            builder.append(importLine).append(System.lineSeparator());
+        }
+        builder.append(System.lineSeparator());
+        for (int i = classLineIndex; i < lines.length; i++) {
+            builder.append(lines[i]);
+            if (i < lines.length - 1) {
+                builder.append(System.lineSeparator());
+            }
+        }
+        if (!source.endsWith(System.lineSeparator())) {
+            builder.append(System.lineSeparator());
+        }
+        return builder.toString();
+    }
+
+    private boolean containsVarUsage(String methodSource) {
+        if (methodSource == null) {
+            return false;
+        }
+        return VAR_PATTERN.matcher(methodSource).find();
+    }
+
+    private static final class GeneratedSnippet {
+        private final List<String> imports;
+        private final String methodSource;
+
+        private GeneratedSnippet(List<String> imports, String methodSource) {
+            this.imports = imports == null ? List.of() : List.copyOf(imports);
+            this.methodSource = methodSource;
+        }
+
+        private List<String> imports() {
+            return imports;
+        }
+
+        private String methodSource() {
+            return methodSource;
+        }
     }
 
     private List<ClassMetadata> resolveInnerTypeMetadata(ClassMetadata target, List<ClassMetadata> discovered) {

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -1,9 +1,14 @@
 package com.example.tests.generator.diff;
 
 import com.example.agent.providers.LLMClient;
+import com.example.tests.generator.metadata.MetadataTransformer;
 import com.example.tests.generator.model.ClassMetadata;
 import com.example.tests.generator.model.MethodMetadata;
 import com.example.tests.generator.model.MethodMetadata.Parameter;
+import com.example.tests.generator.pipeline.GeneratedTestClass;
+import com.example.tests.generator.validate.ResponseValidator;
+import com.example.tests.generator.validate.ValidationResult;
+import com.example.tests.generator.verification.GeneratedTestVerifier;
 
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -55,6 +60,8 @@ public class DiffMethodGenerationRunner {
     private final Path workingDirectory;
     private final Path testSourcesRoot;
     private final Path finalFile;
+    private final ResponseValidator responseValidator;
+    private final GeneratedTestVerifier testVerifier;
     private static final Pattern VAR_PATTERN = Pattern.compile("\\bvar\\b");
     private long lastRequestAtNanos;
 
@@ -77,6 +84,8 @@ public class DiffMethodGenerationRunner {
         this.workingDirectory = projectRoot.resolve("build").resolve("diff-method");
         this.testSourcesRoot = projectRoot.resolve(Paths.get("src", "test", "java"));
         this.finalFile = testSourcesRoot.resolve("FinalGeneratedTest.java");
+        this.responseValidator = new ResponseValidator();
+        this.testVerifier = new GeneratedTestVerifier();
         this.lastRequestAtNanos = -1L;
     }
 
@@ -99,6 +108,7 @@ public class DiffMethodGenerationRunner {
             metadataIndex.putIfAbsent(target.getClassName(), target);
         }
         List<ClassMetadata> discoveredList = new ArrayList<>(metadataIndex.values());
+        MetadataTransformer metadataTransformer = new MetadataTransformer(discoveredList);
         List<MethodGenerationStatus> statuses = new ArrayList<>();
         for (ClassMetadata target : targets) {
             List<MethodMetadata> publicMethods = target.getMethods().stream()
@@ -113,7 +123,7 @@ public class DiffMethodGenerationRunner {
             String classContext = buildClassContext(target, discovered);
             LOGGER.info(() -> "class_api_context для " + target.getQualifiedName() + ":\n" + classContext);
             for (MethodMetadata method : publicMethods) {
-                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList);
+                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList, metadataTransformer);
                 statuses.add(status);
             }
         }
@@ -125,12 +135,15 @@ public class DiffMethodGenerationRunner {
                                                  String classContext,
                                                  List<Path> supportSources,
                                                  Map<String, ClassMetadata> metadataIndex,
-                                                 List<ClassMetadata> discoveredList) throws IOException {
+                                                 List<ClassMetadata> discoveredList,
+                                                 MetadataTransformer metadataTransformer) throws IOException {
         List<String> feedback = new ArrayList<>();
         int iterations = 0;
         boolean compiled = false;
         List<String> lastErrors = List.of();
+        List<String> previousCompilationErrors = List.of();
         List<Path> projectSources = collectCompilationSources(owner, metadataIndex);
+        com.example.tests.generator.metadata.ClassMetadata promptMetadata = metadataTransformer.transform(owner);
         while (iterations <= maxRetries) {
             iterations++;
             final int attempt = iterations;
@@ -159,16 +172,29 @@ public class DiffMethodGenerationRunner {
                     : createSkeleton();
             String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method.getName());
             candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource);
+            GeneratedTestClass candidateClass = new GeneratedTestClass("", "FinalGeneratedTest", candidateSource);
+            GeneratedTestClass verifiedClass = testVerifier.verify(candidateClass, promptMetadata, previousCompilationErrors);
+            candidateSource = verifiedClass.getSourceCode();
+            ValidationResult validationResult = responseValidator.validate(candidateSource, promptMetadata);
+            candidateSource = validationResult.getSanitizedCode().orElse(candidateSource);
             Files.createDirectories(finalFile.getParent());
             Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+            if (!validationResult.isValid()) {
+                feedback = validationResult.getErrors();
+                lastErrors = feedback;
+                previousCompilationErrors = List.of();
+                continue;
+            }
             CompilationResult compilation = compileCandidate(finalFile, supportSources, projectSources);
             if (compilation.success()) {
                 compiled = true;
                 lastErrors = List.of();
+                previousCompilationErrors = List.of();
                 break;
             }
             feedback = compilation.errors();
             lastErrors = feedback;
+            previousCompilationErrors = compilation.errors();
         }
         return new MethodGenerationStatus(owner.getQualifiedName(), method.getName(), compiled, iterations, lastErrors);
     }
@@ -194,11 +220,12 @@ public class DiffMethodGenerationRunner {
         prompt.append("- В начале ответа перечисли необходимые import-операторы (каждый в формате 'import ...;'), затем оставь пустую строку и приведи ровно один тестовый метод.\n");
         prompt.append("- Пользуйся только типами и методами из available_api_signatures и стандартной библиотеки Java.\n");
         prompt.append("- Используй явные типы в объявлениях переменных, не применяй ключевое слово var.\n");
+        prompt.append("- Используй короткие имена типов с необходимыми import-операторами; не оставляй fully-qualified имена в коде.\n");
         prompt.append("- Не добавляй объявление класса FinalGeneratedTest и не используй package.\n");
         prompt.append("- Не используй Mockito, AssertJ, Hamcrest и другие внешние фреймворки.\n");
         prompt.append("- Для проверок используй конструкции вида if (... ) { throw new AssertionError(\"описание\"); }.\n");
         prompt.append("- Чтобы подменить зависимости, создавай простые анонимные реализации или реальные объекты с доступными конструкторами.\n");
-        prompt.append("- Не обращайся к методам, которых нет в available_api_signatures.\n");
+        prompt.append("- Создавай и используй только те типы и методы, которые перечислены в available_api_signatures.\n");
         prompt.append("- Тест должен однозначно компилироваться.\n");
         if (!previousErrors.isEmpty()) {
             prompt.append("Предыдущие ошибки компиляции:\n");

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -16,12 +16,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -29,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -76,6 +79,17 @@ public class DiffMethodGenerationRunner {
         Objects.requireNonNull(targets, "targets");
         Objects.requireNonNull(discovered, "discovered");
         Files.createDirectories(workingDirectory);
+        List<Path> supportSources = ensureSupportSources();
+        Map<String, ClassMetadata> metadataIndex = discovered.stream()
+                .collect(Collectors.toMap(ClassMetadata::getQualifiedName, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+        for (ClassMetadata metadata : discovered) {
+            metadataIndex.putIfAbsent(metadata.getClassName(), metadata);
+        }
+        for (ClassMetadata target : targets) {
+            metadataIndex.putIfAbsent(target.getQualifiedName(), target);
+            metadataIndex.putIfAbsent(target.getClassName(), target);
+        }
+        List<ClassMetadata> discoveredList = new ArrayList<>(metadataIndex.values());
         List<MethodGenerationStatus> statuses = new ArrayList<>();
         for (ClassMetadata target : targets) {
             List<MethodMetadata> publicMethods = target.getMethods().stream()
@@ -90,7 +104,7 @@ public class DiffMethodGenerationRunner {
             String classContext = buildClassContext(target, discovered);
             LOGGER.info(() -> "class_api_context для " + target.getQualifiedName() + ":\n" + classContext);
             for (MethodMetadata method : publicMethods) {
-                MethodGenerationStatus status = processMethod(target, method, classContext);
+                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList);
                 statuses.add(status);
             }
         }
@@ -99,7 +113,10 @@ public class DiffMethodGenerationRunner {
 
     private MethodGenerationStatus processMethod(ClassMetadata owner,
                                                  MethodMetadata method,
-                                                 String classContext) throws IOException {
+                                                 String classContext,
+                                                 List<Path> supportSources,
+                                                 Map<String, ClassMetadata> metadataIndex,
+                                                 List<ClassMetadata> discoveredList) throws IOException {
         List<String> feedback = new ArrayList<>();
         int iterations = 0;
         boolean compiled = false;
@@ -108,7 +125,7 @@ public class DiffMethodGenerationRunner {
             iterations++;
             final int attempt = iterations;
             final int totalAttempts = maxRetries + 1;
-            String prompt = buildPrompt(classContext, owner, method, feedback);
+            String prompt = buildPrompt(classContext, owner, method, feedback, metadataIndex, discoveredList);
             LOGGER.info(() -> String.format(Locale.ENGLISH,
                     "Формирование diff-method запроса (%d/%d) для %s#%s",
                     attempt, totalAttempts, owner.getQualifiedName(), method.getName()));
@@ -126,7 +143,7 @@ public class DiffMethodGenerationRunner {
                     : createSkeleton();
             String candidateSource = mergeMethodIntoSource(methodSource.get(), currentSource);
             Files.writeString(candidateFile, candidateSource, StandardCharsets.UTF_8);
-            CompilationResult compilation = compileCandidate(candidateFile);
+            CompilationResult compilation = compileCandidate(candidateFile, supportSources);
             if (compilation.success()) {
                 Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8);
                 compiled = true;
@@ -142,15 +159,28 @@ public class DiffMethodGenerationRunner {
     private String buildPrompt(String classContext,
                                ClassMetadata owner,
                                MethodMetadata method,
-                               List<String> previousErrors) {
+                               List<String> previousErrors,
+                               Map<String, ClassMetadata> metadataIndex,
+                               List<ClassMetadata> discoveredList) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("Вы — помощник, который пишет модульные тесты на JUnit 5.\n");
         prompt.append("class_api_context = ").append(classContext).append('\n');
         prompt.append("target_method = ").append(describeMethod(owner, method)).append('\n');
+        String apiReference = buildApiReference(owner, metadataIndex, discoveredList);
+        if (!apiReference.isBlank()) {
+            prompt.append("available_api_signatures:\n");
+            prompt.append(apiReference);
+        }
         prompt.append("Сгенерируй ровно один тестовый метод внутри класса FinalGeneratedTest.\n");
         prompt.append("Требования:\n");
         prompt.append("- Используй аннотацию @org.junit.jupiter.api.Test.\n");
-        prompt.append("- Не включай объявление класса, только метод.\n");
+        prompt.append("- Не добавляй объявление класса FinalGeneratedTest и не пиши import.\n");
+        prompt.append("- Пользуйся только типами и методами из available_api_signatures и стандартной библиотеки Java.\n");
+        prompt.append("- Все упоминаемые типы указывай полностью квалифицированными именами.\n");
+        prompt.append("- Не используй Mockito, AssertJ, Hamcrest и другие внешние фреймворки.\n");
+        prompt.append("- Для проверок используй конструкции вида if (... ) { throw new AssertionError(\"описание\"); }.\n");
+        prompt.append("- Чтобы подменить зависимости, создавай простые анонимные реализации или реальные объекты с доступными конструкторами.\n");
+        prompt.append("- Не обращайся к методам, которых нет в available_api_signatures.\n");
         prompt.append("- Тест должен однозначно компилироваться.\n");
         if (!previousErrors.isEmpty()) {
             prompt.append("Предыдущие ошибки компиляции:\n");
@@ -162,6 +192,70 @@ public class DiffMethodGenerationRunner {
         return prompt.toString();
     }
 
+    private String buildApiReference(ClassMetadata owner,
+                                     Map<String, ClassMetadata> metadataIndex,
+                                     List<ClassMetadata> discoveredList) {
+        StringBuilder builder = new StringBuilder();
+        List<MethodMetadata> ownerMethods = owner.getMethods().stream()
+                .filter(MethodMetadata::isPublic)
+                .collect(Collectors.toList());
+        if (!ownerMethods.isEmpty()) {
+            builder.append("- Методы класса ").append(owner.getQualifiedName()).append(':').append(System.lineSeparator());
+            for (MethodMetadata method : ownerMethods) {
+                builder.append("  * ").append(describeMethodForReference(owner, method)).append(System.lineSeparator());
+            }
+        }
+
+        Set<String> dependencies = new LinkedHashSet<>(owner.getDependencies());
+        if (!dependencies.isEmpty()) {
+            if (builder.length() > 0) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("- Доступные зависимости: ").append(System.lineSeparator());
+            for (String dependency : dependencies) {
+                ClassMetadata metadata = metadataIndex.get(dependency);
+                if (metadata == null) {
+                    builder.append("  * ").append(dependency).append(" — описание не найдено").append(System.lineSeparator());
+                    continue;
+                }
+                List<MethodMetadata> methods = metadata.getMethods().stream()
+                        .filter(MethodMetadata::isPublic)
+                        .collect(Collectors.toList());
+                builder.append("  * ").append(metadata.getQualifiedName()).append(System.lineSeparator());
+                if (methods.isEmpty()) {
+                    builder.append("      (нет публичных методов)").append(System.lineSeparator());
+                    continue;
+                }
+                for (MethodMetadata method : methods) {
+                    builder.append("    - ").append(describeMethodForReference(metadata, method)).append(System.lineSeparator());
+                }
+            }
+        }
+
+        List<ClassMetadata> innerTypeMetadata = resolveInnerTypeMetadata(owner, discoveredList);
+        if (!innerTypeMetadata.isEmpty()) {
+            if (builder.length() > 0) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("- Внутренние типы: ").append(System.lineSeparator());
+            for (ClassMetadata metadata : innerTypeMetadata) {
+                builder.append("  * ").append(metadata.getQualifiedName()).append(System.lineSeparator());
+                List<MethodMetadata> methods = metadata.getMethods().stream()
+                        .filter(MethodMetadata::isPublic)
+                        .collect(Collectors.toList());
+                if (methods.isEmpty()) {
+                    builder.append("      (нет публичных методов)").append(System.lineSeparator());
+                    continue;
+                }
+                for (MethodMetadata method : methods) {
+                    builder.append("    - ").append(describeMethodForReference(metadata, method)).append(System.lineSeparator());
+                }
+            }
+        }
+
+        return builder.toString();
+    }
+
     private String describeMethod(ClassMetadata owner, MethodMetadata method) {
         String parameters = method.getParameters().stream()
                 .map(Parameter::toString)
@@ -170,6 +264,18 @@ public class DiffMethodGenerationRunner {
         if (parameters.isEmpty()) {
             parameters = "";
         }
+        if (method.isConstructor()) {
+            return ownerName + '(' + parameters + ')';
+        }
+        String qualifier = method.isStatic() ? "static " : "";
+        return qualifier + method.getReturnType() + ' ' + ownerName + '.' + method.getName() + '(' + parameters + ')';
+    }
+
+    private String describeMethodForReference(ClassMetadata owner, MethodMetadata method) {
+        String parameters = method.getParameters().stream()
+                .map(Parameter::toString)
+                .collect(Collectors.joining(", "));
+        String ownerName = owner.getQualifiedName();
         if (method.isConstructor()) {
             return ownerName + '(' + parameters + ')';
         }
@@ -326,11 +432,119 @@ public class DiffMethodGenerationRunner {
                 + "}" + System.lineSeparator();
     }
 
-    private CompilationResult compileCandidate(Path sourceFile) throws IOException {
+    private List<ClassMetadata> resolveInnerTypeMetadata(ClassMetadata target, List<ClassMetadata> discovered) {
+        String qualifiedPrefixDot = target.getQualifiedName() + '.';
+        String qualifiedPrefixDollar = target.getQualifiedName() + '$';
+        return discovered.stream()
+                .filter(candidate -> {
+                    String qualifiedName = candidate.getQualifiedName();
+                    return qualifiedName.startsWith(qualifiedPrefixDot) || qualifiedName.startsWith(qualifiedPrefixDollar);
+                })
+                .sorted(Comparator.comparing(ClassMetadata::getQualifiedName))
+                .collect(Collectors.toList());
+    }
+
+    private List<Path> ensureSupportSources() throws IOException {
+        List<Path> sources = new ArrayList<>();
+        Path stubsRoot = workingDirectory.resolve("stubs");
+        Path junitTest = stubsRoot.resolve(Paths.get("org", "junit", "jupiter", "api", "Test.java"));
+        String testStub = "package org.junit.jupiter.api;" + System.lineSeparator()
+                + System.lineSeparator()
+                + "import java.lang.annotation.ElementType;" + System.lineSeparator()
+                + "import java.lang.annotation.Retention;" + System.lineSeparator()
+                + "import java.lang.annotation.RetentionPolicy;" + System.lineSeparator()
+                + "import java.lang.annotation.Target;" + System.lineSeparator()
+                + System.lineSeparator()
+                + "@Retention(RetentionPolicy.RUNTIME)" + System.lineSeparator()
+                + "@Target(ElementType.METHOD)" + System.lineSeparator()
+                + "public @interface Test {" + System.lineSeparator()
+                + "}" + System.lineSeparator();
+        sources.add(writeStubSource(junitTest, testStub));
+
+        Path assertions = stubsRoot.resolve(Paths.get("org", "junit", "jupiter", "api", "Assertions.java"));
+        String assertionsStub = "package org.junit.jupiter.api;" + System.lineSeparator()
+                + System.lineSeparator()
+                + "public final class Assertions {" + System.lineSeparator()
+                + "    private Assertions() {" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertTrue(boolean condition) {" + System.lineSeparator()
+                + "        if (!condition) {" + System.lineSeparator()
+                + "            throw new AssertionError(\"Condition expected to be true\");" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertTrue(boolean condition, String message) {" + System.lineSeparator()
+                + "        if (!condition) {" + System.lineSeparator()
+                + "            throw new AssertionError(message);" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertFalse(boolean condition) {" + System.lineSeparator()
+                + "        if (condition) {" + System.lineSeparator()
+                + "            throw new AssertionError(\"Condition expected to be false\");" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertEquals(Object expected, Object actual) {" + System.lineSeparator()
+                + "        if (expected == null ? actual != null : !expected.equals(actual)) {" + System.lineSeparator()
+                + "            throw new AssertionError(\"Values are not equal\");" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertEquals(Object expected, Object actual, String message) {" + System.lineSeparator()
+                + "        if (expected == null ? actual != null : !expected.equals(actual)) {" + System.lineSeparator()
+                + "            throw new AssertionError(message);" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertNotNull(Object value) {" + System.lineSeparator()
+                + "        if (value == null) {" + System.lineSeparator()
+                + "            throw new AssertionError(\"Value expected to be non-null\");" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertNotNull(Object value, String message) {" + System.lineSeparator()
+                + "        if (value == null) {" + System.lineSeparator()
+                + "            throw new AssertionError(message);" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertNull(Object value) {" + System.lineSeparator()
+                + "        if (value != null) {" + System.lineSeparator()
+                + "            throw new AssertionError(\"Value expected to be null\");" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void assertNull(Object value, String message) {" + System.lineSeparator()
+                + "        if (value != null) {" + System.lineSeparator()
+                + "            throw new AssertionError(message);" + System.lineSeparator()
+                + "        }" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + System.lineSeparator()
+                + "    public static void fail(String message) {" + System.lineSeparator()
+                + "        throw new AssertionError(message);" + System.lineSeparator()
+                + "    }" + System.lineSeparator()
+                + "}" + System.lineSeparator();
+        sources.add(writeStubSource(assertions, assertionsStub));
+        return sources;
+    }
+
+    private Path writeStubSource(Path file, String content) throws IOException {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        return file;
+    }
+
+    private CompilationResult compileCandidate(Path sourceFile, List<Path> supportSources) throws IOException {
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         List<String> options = buildCompilerOptions();
         try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
-            Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(List.of(sourceFile.toFile()));
+            List<Path> compilationPaths = new ArrayList<>(supportSources);
+            compilationPaths.add(sourceFile);
+            Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(
+                    compilationPaths.stream().map(Path::toFile).collect(Collectors.toList()));
             JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, options, null, compilationUnits);
             boolean success = Boolean.TRUE.equals(task.call());
             List<String> errors = diagnostics.getDiagnostics().stream()

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -170,7 +170,7 @@ public class DiffMethodGenerationRunner {
             String currentSource = Files.exists(finalFile)
                     ? Files.readString(finalFile)
                     : createSkeleton();
-            String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method.getName());
+            String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method);
             candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource);
             GeneratedTestClass candidateClass = new GeneratedTestClass("", "FinalGeneratedTest", candidateSource);
             GeneratedTestClass verifiedClass = testVerifier.verify(candidateClass, promptMetadata, previousCompilationErrors);
@@ -442,10 +442,17 @@ public class DiffMethodGenerationRunner {
         return count;
     }
 
-    private String mergeMethodIntoSource(String methodSource, String currentSource, String methodName) {
+    private String mergeMethodIntoSource(String methodSource, String currentSource, MethodMetadata method) {
         int insertionPoint;
         String sanitized = methodSource.strip();
-        String withoutExisting = removeExistingMethod(currentSource, methodName);
+        String withoutExisting = currentSource;
+        Optional<String> declaredMethodName = extractDeclaredMethodName(sanitized);
+        if (declaredMethodName.isPresent()) {
+            withoutExisting = removeExistingMethod(withoutExisting, declaredMethodName.get());
+        }
+        if (!method.getName().isBlank()) {
+            withoutExisting = removeExistingMethod(withoutExisting, method.getName());
+        }
         insertionPoint = withoutExisting.lastIndexOf('}');
         if (insertionPoint < 0) {
             throw new IllegalStateException("FinalGeneratedTest.java is malformed: missing class terminator");
@@ -471,53 +478,118 @@ public class DiffMethodGenerationRunner {
     }
 
     private String removeExistingMethod(String source, String methodName) {
-        Optional<String> existingBlock = extractMethodBlock(source, methodName);
-        if (existingBlock.isEmpty()) {
+        if (methodName == null || methodName.isBlank()) {
             return source;
         }
-        String block = existingBlock.get();
-        int index = source.indexOf(block);
-        if (index < 0) {
-            return source;
-        }
-        int removalStart = index;
-        while (removalStart > 0) {
-            char previous = source.charAt(removalStart - 1);
-            if (previous == '\n') {
-                removalStart--;
-                if (removalStart > 0 && source.charAt(removalStart - 1) == '\r') {
+        String updated = source;
+        while (true) {
+            Optional<String> existingBlock = extractMethodBlock(updated, methodName);
+            if (existingBlock.isEmpty()) {
+                break;
+            }
+            String block = existingBlock.get();
+            int index = updated.indexOf(block);
+            if (index < 0) {
+                break;
+            }
+            int removalStart = index;
+            while (removalStart > 0) {
+                char previous = updated.charAt(removalStart - 1);
+                if (previous == '\n') {
                     removalStart--;
+                    if (removalStart > 0 && updated.charAt(removalStart - 1) == '\r') {
+                        removalStart--;
+                    }
+                    break;
                 }
-                break;
+                if (!Character.isWhitespace(previous)) {
+                    break;
+                }
+                removalStart--;
             }
-            if (!Character.isWhitespace(previous)) {
-                break;
-            }
-            removalStart--;
-        }
-        int end = index + block.length();
-        while (end < source.length()) {
-            char current = source.charAt(end);
-            if (current == '\r') {
-                end++;
-                if (end < source.length() && source.charAt(end) == '\n') {
+            int end = index + block.length();
+            while (end < updated.length()) {
+                char current = updated.charAt(end);
+                if (current == '\r') {
                     end++;
+                    if (end < updated.length() && updated.charAt(end) == '\n') {
+                        end++;
+                    }
+                    break;
                 }
-                break;
-            }
-            if (current == '\n') {
+                if (current == '\n') {
+                    end++;
+                    break;
+                }
+                if (!Character.isWhitespace(current)) {
+                    break;
+                }
                 end++;
-                break;
             }
-            if (!Character.isWhitespace(current)) {
-                break;
-            }
-            end++;
+            updated = updated.substring(0, removalStart) + updated.substring(end);
         }
-        StringBuilder builder = new StringBuilder();
-        builder.append(source, 0, removalStart);
-        builder.append(source.substring(end));
-        return builder.toString();
+        return updated;
+    }
+
+    private Optional<String> extractDeclaredMethodName(String methodSource) {
+        if (methodSource == null) {
+            return Optional.empty();
+        }
+        String sanitized = methodSource.strip();
+        if (sanitized.isEmpty()) {
+            return Optional.empty();
+        }
+        StringBuilder signatureBuilder = new StringBuilder();
+        String[] lines = sanitized.split("\\R");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (trimmed.startsWith("@")) {
+                continue;
+            }
+            signatureBuilder.append(trimmed).append(' ');
+            if (trimmed.contains("(") || trimmed.contains("{")) {
+                break;
+            }
+        }
+        String signature = signatureBuilder.toString().trim();
+        if (signature.isEmpty()) {
+            return Optional.empty();
+        }
+        int parenIndex = signature.indexOf('(');
+        if (parenIndex < 0) {
+            return Optional.empty();
+        }
+        String beforeParen = signature.substring(0, parenIndex).trim();
+        if (beforeParen.isEmpty()) {
+            return Optional.empty();
+        }
+        String[] tokens = beforeParen.split("\\s+");
+        if (tokens.length == 0) {
+            return Optional.empty();
+        }
+        String candidate = tokens[tokens.length - 1];
+        if (!isValidJavaIdentifier(candidate)) {
+            return Optional.empty();
+        }
+        return Optional.of(candidate);
+    }
+
+    private boolean isValidJavaIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty()) {
+            return false;
+        }
+        if (!Character.isJavaIdentifierStart(identifier.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < identifier.length(); i++) {
+            if (!Character.isJavaIdentifierPart(identifier.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private String createSkeleton() {

--- a/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
+++ b/src/main/java/com/example/tests/generator/diff/DiffMethodGenerationRunner.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -59,7 +60,6 @@ public class DiffMethodGenerationRunner {
     private final JavaCompiler compiler;
     private final Path workingDirectory;
     private final Path testSourcesRoot;
-    private final Path finalFile;
     private final ResponseValidator responseValidator;
     private final GeneratedTestVerifier testVerifier;
     private static final Pattern VAR_PATTERN = Pattern.compile("\\bvar\\b");
@@ -83,7 +83,6 @@ public class DiffMethodGenerationRunner {
         }
         this.workingDirectory = projectRoot.resolve("build").resolve("diff-method");
         this.testSourcesRoot = projectRoot.resolve(Paths.get("src", "test", "java"));
-        this.finalFile = testSourcesRoot.resolve("FinalGeneratedTest.java");
         this.responseValidator = new ResponseValidator();
         this.testVerifier = new GeneratedTestVerifier();
         this.lastRequestAtNanos = -1L;
@@ -94,9 +93,6 @@ public class DiffMethodGenerationRunner {
         Objects.requireNonNull(discovered, "discovered");
         Files.createDirectories(workingDirectory);
         Files.createDirectories(testSourcesRoot);
-        if (Files.notExists(finalFile)) {
-            Files.writeString(finalFile, createSkeleton(), StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
-        }
         List<Path> supportSources = ensureSupportSources();
         Map<String, ClassMetadata> metadataIndex = discovered.stream()
                 .collect(Collectors.toMap(ClassMetadata::getQualifiedName, Function.identity(), (left, right) -> left, LinkedHashMap::new));
@@ -122,12 +118,37 @@ public class DiffMethodGenerationRunner {
             }
             String classContext = buildClassContext(target, discovered);
             LOGGER.info(() -> "class_api_context для " + target.getQualifiedName() + ":\n" + classContext);
+            Path finalFile = prepareFinalTestFile(target);
             for (MethodMetadata method : publicMethods) {
-                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList, metadataTransformer);
+                MethodGenerationStatus status = processMethod(target, method, classContext, supportSources, metadataIndex, discoveredList, metadataTransformer, finalFile);
                 statuses.add(status);
             }
         }
         return new GenerationSummary(statuses);
+    }
+
+    private Path prepareFinalTestFile(ClassMetadata owner) throws IOException {
+        Path finalFile = resolveFinalFile(owner);
+        Files.createDirectories(finalFile.getParent());
+        if (Files.notExists(finalFile)) {
+            Files.writeString(finalFile, createSkeleton(owner.getPackageName()), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW);
+        }
+        return finalFile;
+    }
+
+    private Path resolveFinalFile(ClassMetadata owner) {
+        String packageName = owner.getPackageName();
+        if (packageName == null || packageName.isBlank()) {
+            return testSourcesRoot.resolve("FinalGeneratedTest.java");
+        }
+        Path packagePath = testSourcesRoot;
+        for (String segment : packageName.split("\\.")) {
+            if (!segment.isBlank()) {
+                packagePath = packagePath.resolve(segment);
+            }
+        }
+        return packagePath.resolve("FinalGeneratedTest.java");
     }
 
     private MethodGenerationStatus processMethod(ClassMetadata owner,
@@ -136,7 +157,8 @@ public class DiffMethodGenerationRunner {
                                                  List<Path> supportSources,
                                                  Map<String, ClassMetadata> metadataIndex,
                                                  List<ClassMetadata> discoveredList,
-                                                 MetadataTransformer metadataTransformer) throws IOException {
+                                                 MetadataTransformer metadataTransformer,
+                                                 Path finalFile) throws IOException {
         List<String> feedback = new ArrayList<>();
         int iterations = 0;
         boolean compiled = false;
@@ -169,14 +191,16 @@ public class DiffMethodGenerationRunner {
             }
             String currentSource = Files.exists(finalFile)
                     ? Files.readString(finalFile)
-                    : createSkeleton();
+                    : createSkeleton(owner.getPackageName());
+            currentSource = ensurePackageDeclaration(currentSource, owner.getPackageName());
             String candidateSource = mergeMethodIntoSource(generatedSnippet.methodSource(), currentSource, method);
             candidateSource = mergeImportsIntoSource(generatedSnippet.imports(), candidateSource);
-            GeneratedTestClass candidateClass = new GeneratedTestClass("", "FinalGeneratedTest", candidateSource);
+            GeneratedTestClass candidateClass = new GeneratedTestClass(owner.getPackageName(), "FinalGeneratedTest", candidateSource);
             GeneratedTestClass verifiedClass = testVerifier.verify(candidateClass, promptMetadata, previousCompilationErrors);
             candidateSource = verifiedClass.getSourceCode();
             ValidationResult validationResult = responseValidator.validate(candidateSource, promptMetadata);
             candidateSource = validationResult.getSanitizedCode().orElse(candidateSource);
+            candidateSource = ensurePackageDeclaration(candidateSource, owner.getPackageName());
             Files.createDirectories(finalFile.getParent());
             Files.writeString(finalFile, candidateSource, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
             if (!validationResult.isValid()) {
@@ -592,12 +616,40 @@ public class DiffMethodGenerationRunner {
         return true;
     }
 
-    private String createSkeleton() {
-        return "import org.junit.jupiter.api.Test;" + System.lineSeparator()
-                + System.lineSeparator()
-                + "public class FinalGeneratedTest {" + System.lineSeparator()
-                + System.lineSeparator()
-                + "}" + System.lineSeparator();
+    private String createSkeleton(String packageName) {
+        StringBuilder builder = new StringBuilder();
+        if (packageName != null && !packageName.isBlank()) {
+            builder.append("package ")
+                    .append(packageName)
+                    .append(';')
+                    .append(System.lineSeparator())
+                    .append(System.lineSeparator());
+        }
+        builder.append("import org.junit.jupiter.api.Test;")
+                .append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .append("public class FinalGeneratedTest {")
+                .append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .append('}')
+                .append(System.lineSeparator());
+        return builder.toString();
+    }
+
+    private String ensurePackageDeclaration(String source, String packageName) {
+        if (packageName == null || packageName.isBlank()) {
+            return source;
+        }
+        Pattern packagePattern = Pattern.compile("(?m)^\\s*package\\s+([^;]+)\\s*;\\s*$");
+        Matcher matcher = packagePattern.matcher(source);
+        if (matcher.find()) {
+            String existing = matcher.group(1).trim();
+            if (existing.equals(packageName)) {
+                return source;
+            }
+            return matcher.replaceFirst("package " + packageName + ';');
+        }
+        return "package " + packageName + ';' + System.lineSeparator() + System.lineSeparator() + source;
     }
 
     private String mergeImportsIntoSource(Collection<String> newImports, String source) {

--- a/src/main/java/com/example/tests/generator/model/MethodMetadata.java
+++ b/src/main/java/com/example/tests/generator/model/MethodMetadata.java
@@ -17,6 +17,7 @@ public final class MethodMetadata {
     private final String description;
     private final List<Parameter> parameters;
     private final List<String> annotations;
+    private final boolean publicMethod;
 
     private MethodMetadata(Builder builder) {
         this.name = Objects.requireNonNull(builder.name, "name");
@@ -26,6 +27,7 @@ public final class MethodMetadata {
         this.description = builder.description == null ? "" : builder.description;
         this.parameters = Collections.unmodifiableList(new ArrayList<>(builder.parameters));
         this.annotations = Collections.unmodifiableList(new ArrayList<>(builder.annotations));
+        this.publicMethod = builder.publicMethod;
     }
 
     public String getName() {
@@ -56,6 +58,10 @@ public final class MethodMetadata {
         return annotations;
     }
 
+    public boolean isPublic() {
+        return publicMethod;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -68,6 +74,7 @@ public final class MethodMetadata {
         private String description;
         private final List<Parameter> parameters = new ArrayList<>();
         private final List<String> annotations = new ArrayList<>();
+        private boolean publicMethod;
 
         private Builder() {
         }
@@ -119,6 +126,11 @@ public final class MethodMetadata {
             if (annotation != null && !annotation.isBlank()) {
                 this.annotations.add(annotation);
             }
+            return this;
+        }
+
+        public Builder publicMethod(boolean publicMethod) {
+            this.publicMethod = publicMethod;
             return this;
         }
 

--- a/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
+++ b/src/main/java/com/example/tests/generator/scanner/ProjectScanner.java
@@ -339,6 +339,7 @@ public class ProjectScanner {
                                 ? classTree.getSimpleName().toString()
                                 : methodTree.getReturnType().toString())
                         .staticMethod(isStatic(methodTree.getModifiers()))
+                        .publicMethod(isPublic(methodTree.getModifiers()))
                         .description("");
 
                 List<? extends VariableTree> parameters = methodTree.getParameters();
@@ -367,6 +368,7 @@ public class ProjectScanner {
                 .description("Record component accessor")
                 .constructor(false)
                 .staticMethod(false)
+                .publicMethod(true)
                 .build();
     }
 
@@ -466,7 +468,8 @@ public class ProjectScanner {
                 .constructor(true)
                 .staticMethod(false)
                 .returnType(classTree.getSimpleName().toString())
-                .description("Canonical record constructor");
+                .description("Canonical record constructor")
+                .publicMethod(true);
         for (RecordComponentInfo component : recordComponents) {
             builder.addParameter(component.type(), component.name());
         }
@@ -531,6 +534,10 @@ public class ProjectScanner {
 
     private boolean isStatic(ModifiersTree modifiers) {
         return modifiers.getFlags().contains(Modifier.STATIC);
+    }
+
+    private boolean isPublic(ModifiersTree modifiers) {
+        return modifiers.getFlags().contains(Modifier.PUBLIC);
     }
 
     private boolean isPrivate(ModifiersTree modifiers) {

--- a/src/main/java/com/example/tests/generator/util/StandardLibraryTypeResolver.java
+++ b/src/main/java/com/example/tests/generator/util/StandardLibraryTypeResolver.java
@@ -1,0 +1,128 @@
+package com.example.tests.generator.util;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Utility that resolves common simple type names used in prompts into their
+ * canonical Java standard-library counterparts. This keeps the mapping in one
+ * place so both prompt builders and verifiers can stay in sync when deciding
+ * which imports should be generated automatically.
+ */
+public final class StandardLibraryTypeResolver {
+
+    private static final Map<String, String> SIMPLE_NAME_ALIASES = buildAliases();
+
+    private StandardLibraryTypeResolver() {
+    }
+
+    /**
+     * Attempts to resolve a simple type name into a fully qualified standard
+     * library type. The lookup is case-sensitive and ignores trailing array
+     * markers.
+     */
+    public static Optional<String> resolve(String simpleName) {
+        if (simpleName == null || simpleName.isBlank()) {
+            return Optional.empty();
+        }
+        String candidate = normalise(simpleName);
+        if (candidate.contains(".")) {
+            return isStandardLibrary(candidate) ? Optional.of(candidate) : Optional.empty();
+        }
+        String resolved = SIMPLE_NAME_ALIASES.get(candidate);
+        return resolved == null ? Optional.empty() : Optional.of(resolved);
+    }
+
+    /**
+     * Returns an immutable view of the known simple-name aliases.
+     */
+    public static Map<String, String> aliases() {
+        return SIMPLE_NAME_ALIASES;
+    }
+
+    /**
+     * Determines whether the provided qualified name belongs to the Java
+     * standard library.
+     */
+    public static boolean isStandardLibrary(String qualifiedName) {
+        if (qualifiedName == null || qualifiedName.isBlank()) {
+            return false;
+        }
+        String normalised = qualifiedName.trim();
+        return normalised.startsWith("java.")
+                || normalised.startsWith("javax.")
+                || normalised.startsWith("jakarta.");
+    }
+
+    private static String normalise(String simpleName) {
+        String trimmed = simpleName.trim();
+        while (trimmed.endsWith("[]")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 2);
+        }
+        if (trimmed.endsWith("...")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 3);
+        }
+        return trimmed;
+    }
+
+    private static Map<String, String> buildAliases() {
+        Map<String, String> aliases = new LinkedHashMap<>();
+        register(aliases, "ArrayDeque", "java.util.ArrayDeque");
+        register(aliases, "ArrayList", "java.util.ArrayList");
+        register(aliases, "Arrays", "java.util.Arrays");
+        register(aliases, "BigDecimal", "java.math.BigDecimal");
+        register(aliases, "BigInteger", "java.math.BigInteger");
+        register(aliases, "Collection", "java.util.Collection");
+        register(aliases, "Collections", "java.util.Collections");
+        register(aliases, "Comparator", "java.util.Comparator");
+        register(aliases, "Deque", "java.util.Deque");
+        register(aliases, "EnumMap", "java.util.EnumMap");
+        register(aliases, "EnumSet", "java.util.EnumSet");
+        register(aliases, "HashMap", "java.util.HashMap");
+        register(aliases, "HashSet", "java.util.HashSet");
+        register(aliases, "Instant", "java.time.Instant");
+        register(aliases, "LinkedHashMap", "java.util.LinkedHashMap");
+        register(aliases, "LinkedHashSet", "java.util.LinkedHashSet");
+        register(aliases, "LinkedList", "java.util.LinkedList");
+        register(aliases, "List", "java.util.List");
+        register(aliases, "LocalDate", "java.time.LocalDate");
+        register(aliases, "LocalDateTime", "java.time.LocalDateTime");
+        register(aliases, "LocalTime", "java.time.LocalTime");
+        register(aliases, "Map", "java.util.Map");
+        register(aliases, "Map.Entry", "java.util.Map.Entry");
+        register(aliases, "Month", "java.time.Month");
+        register(aliases, "Objects", "java.util.Objects");
+        register(aliases, "Optional", "java.util.Optional");
+        register(aliases, "Queue", "java.util.Queue");
+        register(aliases, "Set", "java.util.Set");
+        register(aliases, "Stream", "java.util.stream.Stream");
+        register(aliases, "Collectors", "java.util.stream.Collectors");
+        register(aliases, "Supplier", "java.util.function.Supplier");
+        register(aliases, "Function", "java.util.function.Function");
+        register(aliases, "Consumer", "java.util.function.Consumer");
+        register(aliases, "Predicate", "java.util.function.Predicate");
+        register(aliases, "Duration", "java.time.Duration");
+        register(aliases, "UUID", "java.util.UUID");
+        register(aliases, "TreeMap", "java.util.TreeMap");
+        register(aliases, "TreeSet", "java.util.TreeSet");
+        register(aliases, "NavigableMap", "java.util.NavigableMap");
+        register(aliases, "NavigableSet", "java.util.NavigableSet");
+        register(aliases, "SortedMap", "java.util.SortedMap");
+        register(aliases, "SortedSet", "java.util.SortedSet");
+        register(aliases, "AtomicInteger", "java.util.concurrent.atomic.AtomicInteger");
+        register(aliases, "AtomicLong", "java.util.concurrent.atomic.AtomicLong");
+        register(aliases, "ConcurrentHashMap", "java.util.concurrent.ConcurrentHashMap");
+        register(aliases, "CopyOnWriteArrayList", "java.util.concurrent.CopyOnWriteArrayList");
+        register(aliases, "CopyOnWriteArraySet", "java.util.concurrent.CopyOnWriteArraySet");
+        return Collections.unmodifiableMap(aliases);
+    }
+
+    private static void register(Map<String, String> aliases, String simple, String qualified) {
+        Objects.requireNonNull(simple, "simple");
+        Objects.requireNonNull(qualified, "qualified");
+        aliases.putIfAbsent(simple, qualified);
+    }
+}

--- a/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
+++ b/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
@@ -13,19 +13,24 @@ import javax.tools.ToolProvider;
 import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.metadata.RelatedTypeMetadata;
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreeScanner;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -122,9 +127,12 @@ public class ResponseValidator {
             errors.add("Disallowed assertion libraries detected (e.g., AssertJ). Use only JUnit and Mockito.");
         }
 
+        errors.addAll(checkTestAssertions(parseResult.compilationUnits));
+
         if (metadata != null) {
             errors.addAll(checkInstantiationRestrictions(parseResult.compilationUnits, metadata));
             errors.addAll(checkSupportedApiUsage(parseResult.compilationUnits, metadata));
+            errors.addAll(checkLambdaPlaceholders(parseResult.compilationUnits, metadata));
             errors.addAll(simulateCompilation(code.get(), metadata));
         }
 
@@ -300,6 +308,114 @@ public class ResponseValidator {
         return scanner.errors();
     }
 
+    private List<String> checkTestAssertions(List<CompilationUnitTree> units) {
+        List<String> errors = new ArrayList<>();
+        for (CompilationUnitTree unit : units) {
+            for (Tree declaration : unit.getTypeDecls()) {
+                if (!(declaration instanceof ClassTree classTree)) {
+                    continue;
+                }
+                for (Tree member : classTree.getMembers()) {
+                    if (!(member instanceof MethodTree methodTree)) {
+                        continue;
+                    }
+                    if (!isTestMethod(methodTree)) {
+                        continue;
+                    }
+                    if (!containsAssertion(methodTree)) {
+                        errors.add(String.format(Locale.ENGLISH,
+                                "Test method %s must contain at least one assertion or explicit failure.",
+                                methodTree.getName()));
+                    }
+                }
+            }
+        }
+        return errors;
+    }
+
+    private boolean isTestMethod(MethodTree methodTree) {
+        return methodTree.getModifiers().getAnnotations().stream()
+                .map(this::annotationSimpleName)
+                .anyMatch(name -> name.equals("Test"));
+    }
+
+    private boolean containsAssertion(MethodTree methodTree) {
+        AssertionScanner scanner = new AssertionScanner();
+        scanner.scan(methodTree, null);
+        return scanner.foundAssertion();
+    }
+
+    private List<String> checkLambdaPlaceholders(List<CompilationUnitTree> units, ClassMetadata metadata) {
+        if (metadata == null) {
+            return List.of();
+        }
+        Set<String> dependencySimpleNames = new LinkedHashSet<>();
+        dependencySimpleNames.add(metadata.getClassName());
+        dependencySimpleNames.addAll(metadata.getDependencies().stream()
+                .map(ResponseValidator::extractSimpleName)
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
+        for (RelatedTypeMetadata related : metadata.getSupportingTypes()) {
+            dependencySimpleNames.add(ResponseValidator.extractSimpleName(related.getQualifiedName()));
+            dependencySimpleNames.add(related.getClassName());
+        }
+
+        List<String> errors = new ArrayList<>();
+        TreePathScanner<Void, Void> scanner = new TreePathScanner<>() {
+            @Override
+            public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
+                if (isPlaceholderLambda(node)) {
+                    TreePath path = getCurrentPath();
+                    Tree parent = path != null && path.getParentPath() != null
+                            ? path.getParentPath().getLeaf()
+                            : null;
+                    if (isDependencyContext(parent)) {
+                        errors.add("Do not use empty lambda expressions for domain dependencies; create an explicit stub implementation instead.");
+                    }
+                }
+                return super.visitLambdaExpression(node, null);
+            }
+
+            private boolean isDependencyContext(Tree parent) {
+                if (parent == null) {
+                    return false;
+                }
+                if (parent instanceof VariableTree variableTree) {
+                    Tree type = variableTree.getType();
+                    if (type != null) {
+                        String simple = extractSimpleName(type.toString());
+                        return dependencySimpleNames.contains(simple);
+                    }
+                }
+                if (parent instanceof NewClassTree newClassTree) {
+                    String identifier = newClassTree.getIdentifier().toString();
+                    String simple = extractSimpleName(identifier);
+                    return dependencySimpleNames.contains(simple);
+                }
+                if (parent instanceof MethodInvocationTree methodInvocationTree) {
+                    String selector = methodInvocationTree.getMethodSelect().toString();
+                    String simple = extractSimpleName(selector);
+                    if (simple.toLowerCase(Locale.ENGLISH).startsWith("assert")) {
+                        return false;
+                    }
+                    if (simple.equals("fail")) {
+                        return false;
+                    }
+                    TreePath parentPath = getCurrentPath().getParentPath();
+                    if (parentPath != null) {
+                        Tree grandParent = parentPath.getParentPath() != null ? parentPath.getParentPath().getLeaf() : null;
+                        return isDependencyContext(grandParent);
+                    }
+                }
+                return false;
+            }
+        };
+
+        for (CompilationUnitTree unit : units) {
+            scanner.scan(unit, null);
+        }
+        return errors;
+    }
+
     private void registerRestrictedType(String simpleName,
                                         String qualifiedName,
                                         boolean interfaceType,
@@ -335,6 +451,60 @@ public class ResponseValidator {
     private static String extractSimpleName(String identifier) {
         int lastDot = identifier.lastIndexOf('.');
         return lastDot >= 0 ? identifier.substring(lastDot + 1) : identifier;
+    }
+
+    private boolean isPlaceholderLambda(LambdaExpressionTree lambdaExpressionTree) {
+        if (lambdaExpressionTree.getBody() instanceof BlockTree blockTree) {
+            return blockTree.getStatements().isEmpty();
+        }
+        ExpressionTree body = (ExpressionTree) lambdaExpressionTree.getBody();
+        String representation = body.toString().trim();
+        return representation.equals("null") || representation.isEmpty();
+    }
+
+    private boolean isAssertionCall(MethodInvocationTree invocationTree) {
+        ExpressionTree select = invocationTree.getMethodSelect();
+        String simpleName;
+        if (select instanceof MemberSelectTree memberSelectTree) {
+            simpleName = memberSelectTree.getIdentifier().toString();
+        } else if (select instanceof IdentifierTree identifierTree) {
+            simpleName = identifierTree.getName().toString();
+        } else {
+            simpleName = select.toString();
+        }
+        String lower = simpleName.toLowerCase(Locale.ENGLISH);
+        return lower.startsWith("assert") || lower.equals("fail");
+    }
+
+    private final class AssertionScanner extends TreeScanner<Void, Void> {
+
+        private boolean found;
+
+        @Override
+        public Void visitMethodInvocation(MethodInvocationTree node, Void unused) {
+            if (isAssertionCall(node)) {
+                found = true;
+                return null;
+            }
+            return super.visitMethodInvocation(node, unused);
+        }
+
+        @Override
+        public Void visitThrow(ThrowTree node, Void unused) {
+            ExpressionTree expression = node.getExpression();
+            if (expression instanceof NewClassTree newClassTree) {
+                String identifier = newClassTree.getIdentifier().toString();
+                if (extractSimpleName(identifier).equals("AssertionError")) {
+                    found = true;
+                    return null;
+                }
+            }
+            return super.visitThrow(node, unused);
+        }
+
+        boolean foundAssertion() {
+            return found;
+        }
     }
 
     private String annotationSimpleName(AnnotationTree annotation) {

--- a/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
+++ b/src/main/java/com/example/tests/generator/validate/ResponseValidator.java
@@ -65,6 +65,9 @@ public class ResponseValidator {
     private static final Pattern TYPE_PATTERN = Pattern.compile("(?m)^\\s*public\\s+(?:[A-Za-z]+\\s+)*(class|interface|enum|record)\\s+([A-Za-z0-9_]+)");
     private static final Pattern SYMBOL_PATTERN = Pattern.compile("symbol:\\s+(class|interface|enum|method|variable)\\s+([A-Za-z0-9_]+)");
     private static final Pattern PACKAGE_MISSING_PATTERN = Pattern.compile("package\\s+([a-zA-Z0-9_.]+)\\s+does\\s+not\\s+exist");
+    private static final Pattern CONSTRUCTOR_MISMATCH_PATTERN = Pattern.compile(
+            "constructor\\s+([A-Za-z0-9_.]+)\\s+in\\s+class\\s+([A-Za-z0-9_.]+)\\s+cannot\\s+be\\s+applied\\s+to\\s+given\\s+types",
+            Pattern.CASE_INSENSITIVE);
     private static final Set<String> IMPLICITLY_AVAILABLE_ANNOTATIONS = Set.of(
             "Override",
             "Deprecated",
@@ -621,6 +624,13 @@ public class ResponseValidator {
                         symbol);
                 default -> null;
             };
+        }
+        Matcher constructorMatcher = CONSTRUCTOR_MISMATCH_PATTERN.matcher(message);
+        if (constructorMatcher.find()) {
+            String constructorOwner = constructorMatcher.group(2);
+            return String.format(Locale.ENGLISH,
+                    "Constructor for %s cannot be used with the provided arguments. Use one of the available signatures documented in the prompt or adjust the test setup.",
+                    constructorOwner);
         }
         return null;
     }

--- a/src/main/java/com/example/tests/generator/verification/GeneratedTestVerifier.java
+++ b/src/main/java/com/example/tests/generator/verification/GeneratedTestVerifier.java
@@ -3,6 +3,7 @@ package com.example.tests.generator.verification;
 import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
 import com.example.tests.generator.verification.rules.DependencyFieldCleanupRule;
+import com.example.tests.generator.verification.rules.FullyQualifiedTypeImportRule;
 import com.example.tests.generator.verification.rules.ImportSanitizerRule;
 import com.example.tests.generator.verification.rules.MethodSignatureNormalizationRule;
 import com.example.tests.generator.verification.rules.MockitoCompilationFixRule;
@@ -24,6 +25,7 @@ public final class GeneratedTestVerifier {
     public GeneratedTestVerifier() {
         this(List.of(
                 new MockitoCompilationFixRule(),
+                new FullyQualifiedTypeImportRule(),
                 new ImportSanitizerRule(),
                 new MethodSignatureNormalizationRule(),
                 new DependencyFieldCleanupRule(),

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -324,6 +324,10 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         if (simpleToQualified.containsKey(type)) {
             return simpleToQualified.get(type);
         }
+        Optional<String> standard = StandardLibraryTypeResolver.resolve(type);
+        if (standard.isPresent()) {
+            return standard.get();
+        }
         if (type.contains(".")) {
             int firstDot = type.indexOf('.');
             if (firstDot > 0 && Character.isLowerCase(type.charAt(0))) {
@@ -332,6 +336,9 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         }
         String simpleName = extractSimpleName(type);
         String candidate = simpleToQualified.get(simpleName);
+        if (candidate == null) {
+            candidate = StandardLibraryTypeResolver.resolve(simpleName).orElse(null);
+        }
         if (candidate != null) {
             if (type.contains(".")) {
                 int lastDot = type.lastIndexOf('.');

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -249,6 +249,14 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             if (canonicalOwner == null) {
                 canonicalOwner = StandardLibraryTypeResolver.resolve(ownerSimple).orElse(null);
             }
+            if (canonicalOwner != null && !canonicalOwner.contains(".")) {
+                String metadataQualified = simpleToQualified.get(canonicalOwner);
+                if (metadataQualified != null) {
+                    canonicalOwner = metadataQualified;
+                } else {
+                    canonicalOwner = StandardLibraryTypeResolver.resolve(canonicalOwner).orElse(canonicalOwner);
+                }
+            }
             if (canonicalOwner == null || canonicalOwner.equals(ownerSimple)) {
                 matcher.appendReplacement(buffer, matcher.group(0));
                 continue;

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -44,6 +44,12 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             modified = true;
         }
 
+        String cleanedImports = removeUnqualifiedImports(source);
+        if (!cleanedImports.equals(source)) {
+            source = cleanedImports;
+            modified = true;
+        }
+
         for (Map.Entry<String, String> entry : metadataTypes.entrySet()) {
             String qualified = entry.getKey();
             String simple = entry.getValue();
@@ -215,6 +221,20 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         if (!modified) {
             return source;
         }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private String removeUnqualifiedImports(String source) {
+        Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+([\\w\\$]+)\\s*;\\s*$");
+        Matcher matcher = malformedImport.matcher(source);
+        if (!matcher.find()) {
+            return source;
+        }
+        StringBuffer buffer = new StringBuffer();
+        do {
+            matcher.appendReplacement(buffer, "");
+        } while (matcher.find());
         matcher.appendTail(buffer);
         return buffer.toString();
     }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -204,7 +204,10 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         while (matcher.find()) {
             String current = matcher.group(1).trim();
             String canonical = canonicalImport(current, simpleToQualified);
-            if (!current.equals(canonical)) {
+            if (canonical == null) {
+                matcher.appendReplacement(buffer, "");
+                modified = true;
+            } else if (!current.equals(canonical)) {
                 matcher.appendReplacement(buffer, "import " + canonical + ";");
                 modified = true;
             }
@@ -228,7 +231,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         if (declaredImport.contains(".")) {
             return declaredImport;
         }
-        return declaredImport;
+        return null;
     }
 
     private static final Map<String, String> STANDARD_TYPE_ALIASES = Map.ofEntries(

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -153,7 +153,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         Matcher matcher = packagePattern.matcher(source);
         if (matcher.find()) {
             int end = matcher.end();
-            while (end < source.length() && (source.charAt(end) == '\\r' || source.charAt(end) == '\\n')) {
+            while (end < source.length() && (source.charAt(end) == '\r' || source.charAt(end) == '\n')) {
                 end++;
             }
             return end;

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -1,0 +1,163 @@
+package com.example.tests.generator.verification.rules;
+
+import com.example.tests.generator.metadata.ClassMetadata;
+import com.example.tests.generator.metadata.RelatedTypeMetadata;
+import com.example.tests.generator.verification.GeneratedTestContext;
+import com.example.tests.generator.verification.GeneratedTestRule;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Rewrites fully-qualified type usages into canonical imports and short names
+ * whenever the type belongs to the analysed domain or to the Java standard
+ * library. This keeps the generated test readable even when the language model
+ * omits import statements in its response.
+ */
+public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
+
+    private static final Pattern JAVA_TYPE_PATTERN = Pattern.compile("\\b(java\\.[a-zA-Z0-9_.]*\\.[A-Z][A-Za-z0-9_]*)\\b");
+
+    @Override
+    public void apply(GeneratedTestContext context) {
+        Objects.requireNonNull(context, "context");
+        String source = context.getSourceCode();
+        boolean modified = false;
+        Set<String> importsToAdd = new LinkedHashSet<>();
+
+        Map<String, String> metadataTypes = collectMetadataTypes(context);
+        Map<String, Long> duplicateCheck = metadataTypes.values().stream()
+                .collect(Collectors.groupingBy(simple -> simple, LinkedHashMap::new, Collectors.counting()));
+        for (Map.Entry<String, String> entry : metadataTypes.entrySet()) {
+            String qualified = entry.getKey();
+            String simple = entry.getValue();
+            if (duplicateCheck.getOrDefault(simple, 0L) > 1) {
+                continue;
+            }
+            Pattern pattern = Pattern.compile("\\b" + Pattern.quote(qualified) + "\\b");
+            Matcher matcher = pattern.matcher(source);
+            if (matcher.find()) {
+                source = matcher.replaceAll(simple);
+                importsToAdd.add(qualified);
+                modified = true;
+            }
+        }
+
+        Matcher javaMatcher = JAVA_TYPE_PATTERN.matcher(source);
+        StringBuffer buffer = new StringBuffer();
+        boolean javaModified = false;
+        while (javaMatcher.find()) {
+            String qualified = javaMatcher.group(1);
+            if (qualified.startsWith("java.lang.")) {
+                continue;
+            }
+            String simple = extractSimpleName(qualified);
+            javaMatcher.appendReplacement(buffer, simple);
+            importsToAdd.add(qualified);
+            javaModified = true;
+        }
+        if (javaModified) {
+            javaMatcher.appendTail(buffer);
+            source = buffer.toString();
+            modified = true;
+        }
+
+        if (!importsToAdd.isEmpty()) {
+            for (String qualified : importsToAdd) {
+                source = ensureImport(source, qualified);
+            }
+            modified = true;
+        }
+
+        if (modified) {
+            context.setSourceCode(source);
+        }
+    }
+
+    private Map<String, String> collectMetadataTypes(GeneratedTestContext context) {
+        Map<String, String> qualifiedToSimple = new LinkedHashMap<>();
+        Optional<ClassMetadata> metadata = context.getMetadata();
+        if (metadata.isEmpty()) {
+            return qualifiedToSimple;
+        }
+        ClassMetadata owner = metadata.get();
+        register(qualifiedToSimple, owner.getFullyQualifiedName());
+        owner.getDependencies().forEach(dependency -> register(qualifiedToSimple, dependency));
+        owner.getSupportingTypes().stream()
+                .map(RelatedTypeMetadata::getQualifiedName)
+                .forEach(type -> register(qualifiedToSimple, type));
+        owner.getDependencyMethods().keySet().forEach(type -> register(qualifiedToSimple, type));
+        owner.getSupportingTypeMembers().keySet().forEach(type -> register(qualifiedToSimple, type));
+        return qualifiedToSimple;
+    }
+
+    private void register(Map<String, String> target, String qualifiedName) {
+        if (qualifiedName == null || qualifiedName.isBlank()) {
+            return;
+        }
+        int lastDot = qualifiedName.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= qualifiedName.length() - 1) {
+            return;
+        }
+        String simple = qualifiedName.substring(lastDot + 1);
+        if (simple.isBlank()) {
+            return;
+        }
+        target.putIfAbsent(qualifiedName, simple);
+    }
+
+    private String extractSimpleName(String qualifiedName) {
+        int lastDot = qualifiedName.lastIndexOf('.');
+        return lastDot >= 0 && lastDot + 1 < qualifiedName.length()
+                ? qualifiedName.substring(lastDot + 1)
+                : qualifiedName;
+    }
+
+    private String ensureImport(String source, String qualified) {
+        if (qualified == null || qualified.isBlank() || qualified.startsWith("java.lang.")) {
+            return source;
+        }
+        Pattern existing = Pattern.compile("(?m)^\\s*import\\s+" + Pattern.quote(qualified) + "\\s*;\\s*$");
+        if (existing.matcher(source).find()) {
+            return source;
+        }
+        int packageEnd = locatePackageStatementEnd(source);
+        StringBuilder builder = new StringBuilder();
+        String importLine = String.format(Locale.ENGLISH, "import %s;\n", qualified);
+        if (packageEnd > 0) {
+            builder.append(source, 0, packageEnd);
+            if (packageEnd > 0 && source.charAt(packageEnd - 1) != '\n') {
+                builder.append('\n');
+            }
+            builder.append(importLine);
+            if (packageEnd >= source.length() || source.charAt(packageEnd) != '\n') {
+                builder.append('\n');
+            }
+            builder.append(source.substring(packageEnd));
+        } else {
+            builder.append(importLine).append('\n').append(source);
+        }
+        return builder.toString();
+    }
+
+    private int locatePackageStatementEnd(String source) {
+        Pattern packagePattern = Pattern.compile("(?m)^\\s*package\\s+[\\w\\.]+\\s*;\\s*$");
+        Matcher matcher = packagePattern.matcher(source);
+        if (matcher.find()) {
+            int end = matcher.end();
+            while (end < source.length() && (source.charAt(end) == '\\r' || source.charAt(end) == '\\n')) {
+                end++;
+            }
+            return end;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -271,7 +271,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
     }
 
     private String removeUnqualifiedImports(String source) {
-        Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+([\\w\\$]+)\\s*;\\s*$");
+        Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+(static\\s+)?([\\w\\$]+)\\s*;\\s*$");
         Matcher matcher = malformedImport.matcher(source);
         if (!matcher.find()) {
             return source;
@@ -288,13 +288,60 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         if (declaredImport == null || declaredImport.isBlank()) {
             return declaredImport;
         }
-        String simpleName = extractSimpleName(declaredImport);
+        boolean isStatic = declaredImport.startsWith("static ");
+        String target = isStatic ? declaredImport.substring("static ".length()).trim() : declaredImport.trim();
+        if (target.isEmpty()) {
+            return null;
+        }
+        String canonicalTarget = canonicalImportTarget(target, simpleToQualified);
+        if (canonicalTarget == null) {
+            return null;
+        }
+        return isStatic ? "static " + canonicalTarget : canonicalTarget;
+    }
+
+    private String canonicalImportTarget(String target, Map<String, String> simpleToQualified) {
+        if (target.contains("(")) {
+            target = target.substring(0, target.indexOf('('));
+        }
+        int memberSeparator = target.lastIndexOf('.');
+        if (memberSeparator < 0) {
+            return canonicalType(target, simpleToQualified);
+        }
+        String ownerPart = target.substring(0, memberSeparator);
+        String memberPart = target.substring(memberSeparator + 1);
+        String canonicalOwner = canonicalType(ownerPart, simpleToQualified);
+        if (canonicalOwner == null) {
+            return null;
+        }
+        return canonicalOwner + '.' + memberPart;
+    }
+
+    private String canonicalType(String type, Map<String, String> simpleToQualified) {
+        if (type == null || type.isBlank()) {
+            return null;
+        }
+        if (simpleToQualified.containsKey(type)) {
+            return simpleToQualified.get(type);
+        }
+        if (type.contains(".")) {
+            int firstDot = type.indexOf('.');
+            if (firstDot > 0 && Character.isLowerCase(type.charAt(0))) {
+                return type;
+            }
+        }
+        String simpleName = extractSimpleName(type);
         String candidate = simpleToQualified.get(simpleName);
         if (candidate != null) {
+            if (type.contains(".")) {
+                int lastDot = type.lastIndexOf('.');
+                String suffix = lastDot >= 0 ? type.substring(lastDot) : "";
+                return candidate + suffix;
+            }
             return candidate;
         }
-        if (declaredImport.contains(".")) {
-            return declaredImport;
+        if (type.contains(".")) {
+            return type;
         }
         return null;
     }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -84,6 +84,8 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             modified = true;
         }
 
+        importsToAdd.addAll(detectMissingSimpleImports(source, canonicalImports));
+
         if (!importsToAdd.isEmpty()) {
             for (String qualified : importsToAdd) {
                 source = ensureImport(source, qualified);
@@ -225,6 +227,48 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         return buffer.toString();
     }
 
+    private Set<String> detectMissingSimpleImports(String source, Map<String, String> simpleToQualified) {
+        Set<String> imports = new LinkedHashSet<>();
+        if (simpleToQualified.isEmpty() || source == null || source.isBlank()) {
+            return imports;
+        }
+        String body = stripHeader(source);
+        for (Map.Entry<String, String> entry : simpleToQualified.entrySet()) {
+            String simple = entry.getKey();
+            String qualified = entry.getValue();
+            if (simple == null || qualified == null || qualified.startsWith("java.lang.")) {
+                continue;
+            }
+            if (!containsSimpleUsage(body, simple)) {
+                continue;
+            }
+            if (hasImport(source, qualified)) {
+                continue;
+            }
+            imports.add(qualified);
+        }
+        return imports;
+    }
+
+    private boolean hasImport(String source, String qualified) {
+        Pattern pattern = Pattern.compile("(?m)^\\s*import\\s+" + Pattern.quote(qualified) + "\\s*;\\s*$");
+        return pattern.matcher(source).find();
+    }
+
+    private boolean containsSimpleUsage(String body, String simple) {
+        if (simple.isBlank()) {
+            return false;
+        }
+        Pattern pattern = Pattern.compile("(?<!\\.)\\b" + Pattern.quote(simple) + "\\b");
+        return pattern.matcher(body).find();
+    }
+
+    private String stripHeader(String source) {
+        Pattern header = Pattern.compile("(?m)^\\s*(?:package\\s+[^;]+;|import\\s+[^;]+;)\\s*");
+        Matcher matcher = header.matcher(source);
+        return matcher.replaceAll("");
+    }
+
     private String removeUnqualifiedImports(String source) {
         Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+([\\w\\$]+)\\s*;\\s*$");
         Matcher matcher = malformedImport.matcher(source);
@@ -261,6 +305,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             Map.entry("HashMap", "java.util.HashMap"),
             Map.entry("Set", "java.util.Set"),
             Map.entry("HashSet", "java.util.HashSet"),
+            Map.entry("Arrays", "java.util.Arrays"),
             Map.entry("Collections", "java.util.Collections"),
             Map.entry("Optional", "java.util.Optional"),
             Map.entry("LocalDate", "java.time.LocalDate"),

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -77,6 +77,12 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             modified = true;
         }
 
+        String collapsed = collapseAssignmentNewlines(source);
+        if (!collapsed.equals(source)) {
+            source = collapsed;
+            modified = true;
+        }
+
         if (modified) {
             context.setSourceCode(source);
         }
@@ -159,5 +165,9 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             return end;
         }
         return 0;
+    }
+
+    private String collapseAssignmentNewlines(String source) {
+        return source.replaceAll("=\\s*\\n\\s*new", "= new");
     }
 }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -2,6 +2,7 @@ package com.example.tests.generator.verification.rules;
 
 import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.metadata.RelatedTypeMetadata;
+import com.example.tests.generator.util.StandardLibraryTypeResolver;
 import com.example.tests.generator.verification.GeneratedTestContext;
 import com.example.tests.generator.verification.GeneratedTestRule;
 
@@ -131,7 +132,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             }
             simpleToQualified.putIfAbsent(simple, entry.getKey());
         }
-        STANDARD_TYPE_ALIASES.forEach(simpleToQualified::putIfAbsent);
+        StandardLibraryTypeResolver.aliases().forEach(simpleToQualified::putIfAbsent);
         return simpleToQualified;
     }
 
@@ -298,24 +299,4 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         return null;
     }
 
-    private static final Map<String, String> STANDARD_TYPE_ALIASES = Map.ofEntries(
-            Map.entry("List", "java.util.List"),
-            Map.entry("ArrayList", "java.util.ArrayList"),
-            Map.entry("Map", "java.util.Map"),
-            Map.entry("HashMap", "java.util.HashMap"),
-            Map.entry("Set", "java.util.Set"),
-            Map.entry("HashSet", "java.util.HashSet"),
-            Map.entry("Arrays", "java.util.Arrays"),
-            Map.entry("Collections", "java.util.Collections"),
-            Map.entry("Optional", "java.util.Optional"),
-            Map.entry("LocalDate", "java.time.LocalDate"),
-            Map.entry("LocalDateTime", "java.time.LocalDateTime"),
-            Map.entry("Instant", "java.time.Instant"),
-            Map.entry("Duration", "java.time.Duration"),
-            Map.entry("BigDecimal", "java.math.BigDecimal"),
-            Map.entry("BigInteger", "java.math.BigInteger"),
-            Map.entry("UUID", "java.util.UUID"),
-            Map.entry("Objects", "java.util.Objects"),
-            Map.entry("Comparator", "java.util.Comparator")
-    );
 }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -45,6 +45,12 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             modified = true;
         }
 
+        String rewrittenStaticImports = rewriteStaticSimpleImports(source, canonicalImports);
+        if (!rewrittenStaticImports.equals(source)) {
+            source = rewrittenStaticImports;
+            modified = true;
+        }
+
         String cleanedImports = removeUnqualifiedImports(source);
         if (!cleanedImports.equals(source)) {
             source = cleanedImports;
@@ -220,6 +226,35 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
                 matcher.appendReplacement(buffer, "import " + canonical + ";");
                 modified = true;
             }
+        }
+        if (!modified) {
+            return source;
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private String rewriteStaticSimpleImports(String source, Map<String, String> simpleToQualified) {
+        if (simpleToQualified.isEmpty()) {
+            return source;
+        }
+        Pattern staticImportPattern = Pattern.compile("(?m)^\\s*import\\s+static\\s+([A-Za-z_$][\\w$]*)((?:\\.[A-Za-z_$][\\w$]*)+)\\s*;\\s*$");
+        Matcher matcher = staticImportPattern.matcher(source);
+        StringBuffer buffer = new StringBuffer();
+        boolean modified = false;
+        while (matcher.find()) {
+            String ownerSimple = matcher.group(1);
+            String memberSuffix = matcher.group(2);
+            String canonicalOwner = canonicalType(ownerSimple, simpleToQualified);
+            if (canonicalOwner == null) {
+                canonicalOwner = StandardLibraryTypeResolver.resolve(ownerSimple).orElse(null);
+            }
+            if (canonicalOwner == null || canonicalOwner.equals(ownerSimple)) {
+                matcher.appendReplacement(buffer, matcher.group(0));
+                continue;
+            }
+            matcher.appendReplacement(buffer, "import static " + canonicalOwner + memberSuffix + ";");
+            modified = true;
         }
         if (!modified) {
             return source;

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -36,6 +36,14 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         Map<String, String> metadataTypes = collectMetadataTypes(context);
         Map<String, Long> duplicateCheck = metadataTypes.values().stream()
                 .collect(Collectors.groupingBy(simple -> simple, LinkedHashMap::new, Collectors.counting()));
+        Map<String, String> canonicalImports = buildCanonicalImportIndex(metadataTypes, duplicateCheck);
+
+        String rewrittenImports = rewriteExistingImports(source, canonicalImports);
+        if (!rewrittenImports.equals(source)) {
+            source = rewrittenImports;
+            modified = true;
+        }
+
         for (Map.Entry<String, String> entry : metadataTypes.entrySet()) {
             String qualified = entry.getKey();
             String simple = entry.getValue();
@@ -105,6 +113,20 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         return qualifiedToSimple;
     }
 
+    private Map<String, String> buildCanonicalImportIndex(Map<String, String> qualifiedToSimple,
+                                                          Map<String, Long> duplicateCheck) {
+        Map<String, String> simpleToQualified = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : qualifiedToSimple.entrySet()) {
+            String simple = entry.getValue();
+            if (duplicateCheck.getOrDefault(simple, 0L) > 1) {
+                continue;
+            }
+            simpleToQualified.putIfAbsent(simple, entry.getKey());
+        }
+        STANDARD_TYPE_ALIASES.forEach(simpleToQualified::putIfAbsent);
+        return simpleToQualified;
+    }
+
     private void register(Map<String, String> target, String qualifiedName) {
         if (qualifiedName == null || qualifiedName.isBlank()) {
             return;
@@ -170,4 +192,62 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
     private String collapseAssignmentNewlines(String source) {
         return source.replaceAll("=\\s*(?:\\r?\\n)\\s*new", "= new");
     }
+
+    private String rewriteExistingImports(String source, Map<String, String> simpleToQualified) {
+        if (simpleToQualified.isEmpty()) {
+            return source;
+        }
+        Pattern importPattern = Pattern.compile("(?m)^\\s*import\\s+([^;]+)\\s*;\\s*$");
+        Matcher matcher = importPattern.matcher(source);
+        StringBuffer buffer = new StringBuffer();
+        boolean modified = false;
+        while (matcher.find()) {
+            String current = matcher.group(1).trim();
+            String canonical = canonicalImport(current, simpleToQualified);
+            if (!current.equals(canonical)) {
+                matcher.appendReplacement(buffer, "import " + canonical + ";");
+                modified = true;
+            }
+        }
+        if (!modified) {
+            return source;
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private String canonicalImport(String declaredImport, Map<String, String> simpleToQualified) {
+        if (declaredImport == null || declaredImport.isBlank()) {
+            return declaredImport;
+        }
+        String simpleName = extractSimpleName(declaredImport);
+        String candidate = simpleToQualified.get(simpleName);
+        if (candidate != null) {
+            return candidate;
+        }
+        if (declaredImport.contains(".")) {
+            return declaredImport;
+        }
+        return declaredImport;
+    }
+
+    private static final Map<String, String> STANDARD_TYPE_ALIASES = Map.ofEntries(
+            Map.entry("List", "java.util.List"),
+            Map.entry("ArrayList", "java.util.ArrayList"),
+            Map.entry("Map", "java.util.Map"),
+            Map.entry("HashMap", "java.util.HashMap"),
+            Map.entry("Set", "java.util.Set"),
+            Map.entry("HashSet", "java.util.HashSet"),
+            Map.entry("Collections", "java.util.Collections"),
+            Map.entry("Optional", "java.util.Optional"),
+            Map.entry("LocalDate", "java.time.LocalDate"),
+            Map.entry("LocalDateTime", "java.time.LocalDateTime"),
+            Map.entry("Instant", "java.time.Instant"),
+            Map.entry("Duration", "java.time.Duration"),
+            Map.entry("BigDecimal", "java.math.BigDecimal"),
+            Map.entry("BigInteger", "java.math.BigInteger"),
+            Map.entry("UUID", "java.util.UUID"),
+            Map.entry("Objects", "java.util.Objects"),
+            Map.entry("Comparator", "java.util.Comparator")
+    );
 }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -45,7 +45,7 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             modified = true;
         }
 
-        String rewrittenStaticImports = rewriteStaticSimpleImports(source, canonicalImports);
+        String rewrittenStaticImports = rewriteStaticImports(source, canonicalImports);
         if (!rewrittenStaticImports.equals(source)) {
             source = rewrittenStaticImports;
             modified = true;
@@ -234,35 +234,33 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         return buffer.toString();
     }
 
-    private String rewriteStaticSimpleImports(String source, Map<String, String> simpleToQualified) {
-        if (simpleToQualified.isEmpty()) {
+    private String rewriteStaticImports(String source, Map<String, String> simpleToQualified) {
+        if (source == null || source.isBlank()) {
             return source;
         }
-        Pattern staticImportPattern = Pattern.compile("(?m)^\\s*import\\s+static\\s+([A-Za-z_$][\\w$]*)((?:\\.[A-Za-z_$][\\w$]*)+)\\s*;\\s*$");
+        Pattern staticImportPattern = Pattern.compile("(?m)^\\s*import\\s+static\\s+([^;]+)\\s*;\\s*$");
         Matcher matcher = staticImportPattern.matcher(source);
         StringBuffer buffer = new StringBuffer();
         boolean modified = false;
         while (matcher.find()) {
-            String ownerSimple = matcher.group(1);
-            String memberSuffix = matcher.group(2);
-            String canonicalOwner = canonicalType(ownerSimple, simpleToQualified);
-            if (canonicalOwner == null) {
-                canonicalOwner = StandardLibraryTypeResolver.resolve(ownerSimple).orElse(null);
+            String target = matcher.group(1).trim();
+            if (!target.contains(".")) {
+                matcher.appendReplacement(buffer, "");
+                modified = true;
+                continue;
             }
-            if (canonicalOwner != null && !canonicalOwner.contains(".")) {
-                String metadataQualified = simpleToQualified.get(canonicalOwner);
-                if (metadataQualified != null) {
-                    canonicalOwner = metadataQualified;
-                } else {
-                    canonicalOwner = StandardLibraryTypeResolver.resolve(canonicalOwner).orElse(canonicalOwner);
-                }
-            }
-            if (canonicalOwner == null || canonicalOwner.equals(ownerSimple)) {
+            String canonicalTarget = canonicalImportTarget(target, simpleToQualified);
+            if (canonicalTarget == null) {
                 matcher.appendReplacement(buffer, matcher.group(0));
                 continue;
             }
-            matcher.appendReplacement(buffer, "import static " + canonicalOwner + memberSuffix + ";");
-            modified = true;
+            String replacement = "import static " + canonicalTarget + ";";
+            if (!matcher.group(0).equals(replacement)) {
+                matcher.appendReplacement(buffer, replacement);
+                modified = true;
+            } else {
+                matcher.appendReplacement(buffer, matcher.group(0));
+            }
         }
         if (!modified) {
             return source;
@@ -314,15 +312,28 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
     }
 
     private String removeUnqualifiedImports(String source) {
-        Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+(static\\s+)?([\\w\\$]+)\\s*;\\s*$");
+        Pattern malformedImport = Pattern.compile("(?m)^\\s*import\\s+(static\\s+)?([^;]+)\\s*;\\s*$");
         Matcher matcher = malformedImport.matcher(source);
-        if (!matcher.find()) {
+        StringBuffer buffer = new StringBuffer();
+        boolean modified = false;
+        while (matcher.find()) {
+            boolean isStatic = matcher.group(1) != null;
+            String target = matcher.group(2).trim();
+            if (target.contains(".")) {
+                matcher.appendReplacement(buffer, matcher.group(0));
+                continue;
+            }
+            if (!isStatic || target.isEmpty()) {
+                matcher.appendReplacement(buffer, "");
+                modified = true;
+                continue;
+            }
+            matcher.appendReplacement(buffer, "");
+            modified = true;
+        }
+        if (!modified) {
             return source;
         }
-        StringBuffer buffer = new StringBuffer();
-        do {
-            matcher.appendReplacement(buffer, "");
-        } while (matcher.find());
         matcher.appendTail(buffer);
         return buffer.toString();
     }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -168,6 +168,6 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
     }
 
     private String collapseAssignmentNewlines(String source) {
-        return source.replaceAll("=\\s*\\n\\s*new", "= new");
+        return source.replaceAll("=\\s*(?:\\r?\\n)\\s*new", "= new");
     }
 }

--- a/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/FullyQualifiedTypeImportRule.java
@@ -6,6 +6,7 @@ import com.example.tests.generator.util.StandardLibraryTypeResolver;
 import com.example.tests.generator.verification.GeneratedTestContext;
 import com.example.tests.generator.verification.GeneratedTestRule;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -242,30 +243,50 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
         Matcher matcher = staticImportPattern.matcher(source);
         StringBuffer buffer = new StringBuffer();
         boolean modified = false;
+        java.util.List<StaticReplacement> replacements = new ArrayList<>();
         while (matcher.find()) {
             String target = matcher.group(1).trim();
-            if (!target.contains(".")) {
-                matcher.appendReplacement(buffer, "");
-                modified = true;
-                continue;
-            }
             String canonicalTarget = canonicalImportTarget(target, simpleToQualified);
+            matcher.appendReplacement(buffer, "");
+            modified = true;
             if (canonicalTarget == null) {
-                matcher.appendReplacement(buffer, matcher.group(0));
                 continue;
             }
-            String replacement = "import static " + canonicalTarget + ";";
-            if (!matcher.group(0).equals(replacement)) {
-                matcher.appendReplacement(buffer, replacement);
-                modified = true;
-            } else {
-                matcher.appendReplacement(buffer, matcher.group(0));
+            int lastDot = canonicalTarget.lastIndexOf('.');
+            if (lastDot <= 0 || lastDot + 1 >= canonicalTarget.length()) {
+                continue;
             }
+            String ownerQualified = canonicalTarget.substring(0, lastDot);
+            String member = canonicalTarget.substring(lastDot + 1);
+            if (member.isBlank()) {
+                continue;
+            }
+            String ownerSimple = extractSimpleName(ownerQualified);
+            replacements.add(new StaticReplacement(ownerSimple, member));
         }
         if (!modified) {
             return source;
         }
         matcher.appendTail(buffer);
+        String result = buffer.toString();
+        for (StaticReplacement replacement : replacements) {
+            result = replaceStaticReference(result, replacement);
+        }
+        return result;
+    }
+
+    private String replaceStaticReference(String source, StaticReplacement replacement) {
+        Pattern usagePattern = Pattern.compile("(?<!\\.)\\b" + Pattern.quote(replacement.member) + "\\b");
+        Matcher usageMatcher = usagePattern.matcher(source);
+        if (!usageMatcher.find()) {
+            return source;
+        }
+        String replacementText = replacement.ownerSimple + '.' + replacement.member;
+        StringBuffer buffer = new StringBuffer();
+        do {
+            usageMatcher.appendReplacement(buffer, replacementText);
+        } while (usageMatcher.find());
+        usageMatcher.appendTail(buffer);
         return buffer.toString();
     }
 
@@ -405,6 +426,16 @@ public final class FullyQualifiedTypeImportRule implements GeneratedTestRule {
             return type;
         }
         return null;
+    }
+
+    private static final class StaticReplacement {
+        private final String ownerSimple;
+        private final String member;
+
+        private StaticReplacement(String ownerSimple, String member) {
+            this.ownerSimple = ownerSimple;
+            this.member = member;
+        }
     }
 
 }

--- a/src/main/java/com/example/tests/generator/verification/rules/ImportSanitizerRule.java
+++ b/src/main/java/com/example/tests/generator/verification/rules/ImportSanitizerRule.java
@@ -33,7 +33,11 @@ public final class ImportSanitizerRule implements GeneratedTestRule {
             }
             lastImportEnd = matcher.end();
             String prefix = matcher.group(1) == null ? "" : "static ";
-            orderedImports.add(prefix + matcher.group(2));
+            String importTarget = matcher.group(2);
+            if (!isQualifiedImport(importTarget)) {
+                continue;
+            }
+            orderedImports.add(prefix + importTarget);
         }
 
         Set<String> requiredImports = collectRequiredImports(source);
@@ -150,6 +154,14 @@ public final class ImportSanitizerRule implements GeneratedTestRule {
             required.add("org.mockito.InjectMocks");
         }
         return required;
+    }
+
+    private boolean isQualifiedImport(String importTarget) {
+        if (importTarget == null || importTarget.isBlank()) {
+            return false;
+        }
+        int dotIndex = importTarget.indexOf('.');
+        return dotIndex > 0;
     }
 
     private int locatePackageStatementEnd(String source) {

--- a/src/test/java/com/example/tests/generator/util/StandardLibraryTypeResolverTest.java
+++ b/src/test/java/com/example/tests/generator/util/StandardLibraryTypeResolverTest.java
@@ -1,0 +1,33 @@
+package com.example.tests.generator.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardLibraryTypeResolverTest {
+
+    @Test
+    void resolvesSimpleAlias() {
+        assertEquals("java.util.HashSet", StandardLibraryTypeResolver.resolve("HashSet").orElseThrow());
+    }
+
+    @Test
+    void resolvesKnownEnumMapAlias() {
+        assertEquals("java.util.EnumMap", StandardLibraryTypeResolver.resolve("EnumMap").orElseThrow());
+    }
+
+    @Test
+    void exposesAliasesAsUnmodifiableMap() {
+        Map<String, String> aliases = StandardLibraryTypeResolver.aliases();
+        assertEquals("java.util.List", aliases.get("List"));
+        assertTrue(aliases.containsKey("Collectors"));
+    }
+
+    @Test
+    void recognisesStandardQualifiedName() {
+        assertTrue(StandardLibraryTypeResolver.isStandardLibrary("java.util.List"));
+    }
+}

--- a/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
+++ b/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
@@ -154,6 +154,27 @@ class ResponseValidatorTest {
     }
 
     @Test
+    void validateRejectsTestsWithoutAssertions() {
+        String response = "```java\n"
+                + "import org.junit.jupiter.api.Test;\n"
+                + "\n"
+                + "public class FlashSaleCoordinatorTest {\n"
+                + "    @Test\n"
+                + "    void shouldFailWithoutAssertions() {\n"
+                + "        String value = \"placeholder\";\n"
+                + "        value.length();\n"
+                + "    }\n"
+                + "}\n"
+                + "```";
+
+        ValidationResult result = validator.validate(response);
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("must contain at least one assertion")));
+    }
+
+    @Test
     void validateRejectsInstantiationOfInterfacesWhenMetadataSupplied() {
         ClassMetadata metadata = ClassMetadata.builder()
                 .packageName("com.example")
@@ -179,6 +200,42 @@ class ResponseValidatorTest {
         assertFalse(result.isValid());
         assertTrue(result.getErrors().stream().anyMatch(error -> error.contains("InvoiceService")));
         assertTrue(result.getSanitizedCode().isPresent());
+    }
+
+    @Test
+    void validateRejectsEmptyLambdaPlaceholdersForDependencies() {
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("FlashSaleCoordinator")
+                .addDependency("com.acme.discount.InventoryGateway")
+                .addSupportingType(RelatedTypeMetadata.builder()
+                        .packageName("com.acme.discount")
+                        .className("InventoryGateway")
+                        .qualifiedName("com.acme.discount.InventoryGateway")
+                        .kind(ClassKind.INTERFACE)
+                        .build())
+                .build();
+
+        String response = "```java\n"
+                + "import com.acme.discount.InventoryGateway;\n"
+                + "import org.junit.jupiter.api.Test;\n"
+                + "\n"
+                + "public class FlashSaleCoordinatorTest {\n"
+                + "    @Test\n"
+                + "    void rejectsEmptyLambdaStubs() {\n"
+                + "        InventoryGateway gateway = () -> {};\n"
+                + "        if (gateway == null) {\n"
+                + "            throw new AssertionError(\"stub\");\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n"
+                + "```";
+
+        ValidationResult result = validator.validate(response, metadata);
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().stream()
+                .anyMatch(error -> error.contains("empty lambda")));
     }
 
     @Test

--- a/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
+++ b/src/test/java/com/example/tests/generator/validate/ResponseValidatorTest.java
@@ -23,12 +23,14 @@ class ResponseValidatorTest {
         String response = "Here is the generated test:\n" +
                 "```java\n" +
                 "import org.junit.jupiter.api.Test;\n" +
+                "import static org.junit.jupiter.api.Assertions.assertNotNull;\n" +
                 "import org.mockito.Mockito;\n" +
                 "\n" +
                 "public class InvoiceServiceTest {\n" +
                 "    @Test\n" +
                 "    void shouldDoSomething() {\n" +
-                "        Mockito.mock(Object.class);\n" +
+                "        Object dependency = Mockito.mock(Object.class);\n" +
+                "        assertNotNull(dependency);\n" +
                 "    }\n" +
                 "}\n" +
                 "```";
@@ -379,6 +381,7 @@ class ResponseValidatorTest {
                 + "import org.junit.jupiter.api.extension.ExtendWith;\n"
                 + "import org.mockito.Mock;\n"
                 + "import org.mockito.junit.jupiter.MockitoExtension;\n"
+                + "import static org.junit.jupiter.api.Assertions.assertNotNull;\n"
                 + "import static org.mockito.BDDMockito.given;\n"
                 + "import static org.mockito.ArgumentMatchers.anyString;\n"
                 + "\n"
@@ -391,6 +394,7 @@ class ResponseValidatorTest {
                 + "    @Test\n"
                 + "    void usesBddMockito() {\n"
                 + "        given(dependency.call(anyString())).willReturn(\"value\");\n"
+                + "        assertNotNull(dependency);\n"
                 + "    }\n"
                 + "\n"
                 + "    private interface Dependency {\n"

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -262,9 +262,10 @@ class GeneratedTestVerifierTest {
         GeneratedTestClass verified = verifier.verify(generated, metadata);
 
         String verifiedSource = verified.getSourceCode();
-        assertThat(verifiedSource).contains("import static java.util.Collections.singletonList;");
-        assertThat(verifiedSource).contains("import static com.acme.discount.ProductCategory.ELECTRONICS;");
-        assertThat(verifiedSource).doesNotContain("import static Collections.singletonList;");
-        assertThat(verifiedSource).doesNotContain("import static ProductCategory.ELECTRONICS;");
+        assertThat(verifiedSource).doesNotContain("import static");
+        assertThat(verifiedSource).contains("import java.util.Collections;");
+        assertThat(verifiedSource).contains("import com.acme.discount.ProductCategory;");
+        assertThat(verifiedSource)
+                .contains("Collections.singletonList(ProductCategory.ELECTRONICS)");
     }
 }

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -193,4 +193,40 @@ class GeneratedTestVerifierTest {
         assertThat(verifiedSource).doesNotContain("import InventoryGateway;");
         assertThat(verifiedSource).doesNotContain("import ArrayList;");
     }
+
+    @Test
+    void addsMissingImportsForStandardAndDomainTypes() {
+        String originalSource = """
+                import org.junit.jupiter.api.Test;
+
+                public class FlashSaleCoordinatorTest {
+
+                    @Test
+                    void addsCanonicalImportsForCollections() {
+                        HashSet<ProductCategory> categories = new HashSet<>(Arrays.asList(ProductCategory.ELECTRONICS));
+                        if (categories.isEmpty()) {
+                            throw new AssertionError("Expected non-empty categories");
+                        }
+                    }
+                }
+                """;
+        RelatedTypeMetadata productCategory = RelatedTypeMetadata.builder()
+                .packageName("com.acme.discount")
+                .className("ProductCategory")
+                .build();
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("FlashSaleCoordinator")
+                .addSupportingType(productCategory)
+                .build();
+
+        GeneratedTestClass generated = new GeneratedTestClass("", "FlashSaleCoordinatorTest", originalSource);
+        GeneratedTestClass verified = verifier.verify(generated, metadata);
+
+        String verifiedSource = verified.getSourceCode();
+        assertThat(verifiedSource).contains("import java.util.HashSet;");
+        assertThat(verifiedSource).contains("import java.util.Arrays;");
+        assertThat(verifiedSource).contains("import com.acme.discount.ProductCategory;");
+        assertThat(verifiedSource).contains("HashSet<ProductCategory> categories = new HashSet<>(Arrays.asList(ProductCategory.ELECTRONICS));");
+    }
 }

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -2,11 +2,11 @@ package com.example.tests.generator.verification;
 
 import com.example.tests.generator.metadata.ClassMetadata;
 import com.example.tests.generator.metadata.MethodMetadata;
+import com.example.tests.generator.metadata.RelatedTypeMetadata;
 import com.example.tests.generator.pipeline.GeneratedTestClass;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GeneratedTestVerifierTest {
@@ -129,5 +129,68 @@ class GeneratedTestVerifierTest {
         assertThat(verifiedSource).doesNotContain("new com.acme.discount.complex.FlashSaleCoordinator");
         assertThat(verifiedSource).doesNotContain("com.acme.discount.complex.FlashSaleCoordinator coordinator");
         assertThat(verifiedSource).doesNotContain("java.time.LocalDate.now");
+    }
+
+    @Test
+    void canonicalisesMalformedImportsUsingMetadata() {
+        String originalSource = """
+                import FlashSaleCoordinator;
+                import DiscountEngine;
+                import InventoryGateway;
+                import NotificationGateway;
+                import ArrayList;
+                import List;
+                import LocalDate;
+                import org.junit.jupiter.api.Test;
+
+                public class FinalGeneratedTest {
+
+                    @Test
+                    void compilesWithCanonicalImports() {
+                        FlashSaleCoordinator coordinator = new com.acme.discount.complex.FlashSaleCoordinator(
+                                new com.acme.discount.DiscountEngine(java.util.List.of()),
+                                new com.acme.discount.complex.InventoryGateway(),
+                                new com.acme.discount.complex.NotificationGateway());
+                        List<String> values = new ArrayList<>();
+                        LocalDate today = LocalDate.now();
+                        if (coordinator == null || values == null || today == null) {
+                            throw new AssertionError("Expected objects to be initialised");
+                        }
+                    }
+                }
+                """;
+        GeneratedTestClass generated = new GeneratedTestClass("", "FinalGeneratedTest", originalSource);
+        RelatedTypeMetadata inventoryGateway = RelatedTypeMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("InventoryGateway")
+                .build();
+        RelatedTypeMetadata notificationGateway = RelatedTypeMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("NotificationGateway")
+                .build();
+
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("FlashSaleCoordinator")
+                .addDependency("com.acme.discount.DiscountEngine")
+                .addSupportingType(inventoryGateway)
+                .addSupportingType(notificationGateway)
+                .putSupportingTypeMembers("com.acme.discount.complex.InventoryGateway", List.of("reserve"))
+                .putSupportingTypeMembers("com.acme.discount.complex.NotificationGateway", List.of("send"))
+                .build();
+
+        GeneratedTestClass verified = verifier.verify(generated, metadata);
+        String verifiedSource = verified.getSourceCode();
+
+        assertThat(verifiedSource).contains("import com.acme.discount.complex.FlashSaleCoordinator;");
+        assertThat(verifiedSource).contains("import com.acme.discount.DiscountEngine;");
+        assertThat(verifiedSource).contains("import com.acme.discount.complex.InventoryGateway;");
+        assertThat(verifiedSource).contains("import com.acme.discount.complex.NotificationGateway;");
+        assertThat(verifiedSource).contains("import java.util.ArrayList;");
+        assertThat(verifiedSource).contains("import java.util.List;");
+        assertThat(verifiedSource).contains("import java.time.LocalDate;");
+        assertThat(verifiedSource).doesNotContain("import FlashSaleCoordinator;");
+        assertThat(verifiedSource).doesNotContain("import InventoryGateway;");
+        assertThat(verifiedSource).doesNotContain("import ArrayList;");
     }
 }

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -91,4 +91,42 @@ class GeneratedTestVerifierTest {
                 .contains("com.example.Calculator.Result result = calculator.calculate();");
         assertThat(verifiedSource).doesNotContain("(DiscountResult)");
     }
+
+    @Test
+    void rewritesFullyQualifiedTypesToCanonicalImports() {
+        String originalSource = """
+                import org.junit.jupiter.api.Test;
+
+                public class FinalGeneratedTest {
+
+                    @Test
+                    void shouldUseDomainTypes() {
+                        com.acme.discount.complex.FlashSaleCoordinator coordinator =
+                                new com.acme.discount.complex.FlashSaleCoordinator(null, null, null);
+                        java.time.LocalDate today = java.time.LocalDate.now();
+                        if (coordinator == null || today == null) {
+                            throw new AssertionError("Expected non-null objects");
+                        }
+                    }
+                }
+                """;
+        GeneratedTestClass generated = new GeneratedTestClass("", "FinalGeneratedTest", originalSource);
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount.complex")
+                .className("FlashSaleCoordinator")
+                .addDependency("com.acme.discount.complex.InventoryGateway")
+                .addDependency("com.acme.discount.complex.NotificationGateway")
+                .addDependency("com.acme.discount.CustomerProfile")
+                .build();
+
+        GeneratedTestClass verified = verifier.verify(generated, metadata);
+        String verifiedSource = verified.getSourceCode();
+
+        assertThat(verifiedSource).contains("import com.acme.discount.complex.FlashSaleCoordinator;");
+        assertThat(verifiedSource).contains("import java.time.LocalDate;");
+        assertThat(verifiedSource).contains("FlashSaleCoordinator coordinator = new FlashSaleCoordinator");
+        assertThat(verifiedSource).contains("LocalDate today = LocalDate.now();");
+        assertThat(verifiedSource).doesNotContain("com.acme.discount.complex.FlashSaleCoordinator");
+        assertThat(verifiedSource).doesNotContain("java.time.LocalDate.now");
+    }
 }

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -229,4 +229,42 @@ class GeneratedTestVerifierTest {
         assertThat(verifiedSource).contains("import com.acme.discount.ProductCategory;");
         assertThat(verifiedSource).contains("HashSet<ProductCategory> categories = new HashSet<>(Arrays.asList(ProductCategory.ELECTRONICS));");
     }
+
+    @Test
+    void canonicalisesStaticImportsForStandardLibraryAndDomainTypes() {
+        String originalSource = """
+                import static Collections.singletonList;
+                import static ProductCategory.ELECTRONICS;
+                import org.junit.jupiter.api.Test;
+
+                public class OrderTest {
+
+                    @Test
+                    void usesStaticHelpers() {
+                        java.util.List<com.acme.discount.ProductCategory> categories = singletonList(ELECTRONICS);
+                        if (categories.isEmpty()) {
+                            throw new AssertionError("Expected non-empty categories");
+                        }
+                    }
+                }
+                """;
+        RelatedTypeMetadata productCategory = RelatedTypeMetadata.builder()
+                .packageName("com.acme.discount")
+                .className("ProductCategory")
+                .build();
+        ClassMetadata metadata = ClassMetadata.builder()
+                .packageName("com.acme.discount")
+                .className("Order")
+                .addSupportingType(productCategory)
+                .build();
+
+        GeneratedTestClass generated = new GeneratedTestClass("", "OrderTest", originalSource);
+        GeneratedTestClass verified = verifier.verify(generated, metadata);
+
+        String verifiedSource = verified.getSourceCode();
+        assertThat(verifiedSource).contains("import static java.util.Collections.singletonList;");
+        assertThat(verifiedSource).contains("import static com.acme.discount.ProductCategory.ELECTRONICS;");
+        assertThat(verifiedSource).doesNotContain("import static Collections.singletonList;");
+        assertThat(verifiedSource).doesNotContain("import static ProductCategory.ELECTRONICS;");
+    }
 }

--- a/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
+++ b/src/test/java/com/example/tests/generator/verification/GeneratedTestVerifierTest.java
@@ -126,7 +126,8 @@ class GeneratedTestVerifierTest {
         assertThat(verifiedSource).contains("import java.time.LocalDate;");
         assertThat(verifiedSource).contains("FlashSaleCoordinator coordinator = new FlashSaleCoordinator");
         assertThat(verifiedSource).contains("LocalDate today = LocalDate.now();");
-        assertThat(verifiedSource).doesNotContain("com.acme.discount.complex.FlashSaleCoordinator");
+        assertThat(verifiedSource).doesNotContain("new com.acme.discount.complex.FlashSaleCoordinator");
+        assertThat(verifiedSource).doesNotContain("com.acme.discount.complex.FlashSaleCoordinator coordinator");
         assertThat(verifiedSource).doesNotContain("java.time.LocalDate.now");
     }
 }

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/TestFixIterationCoordinator.java
@@ -182,12 +182,18 @@ public final class TestFixIterationCoordinator {
     }
 
     private FixApplicationResult applySingleFailureFix(TestContextSnapshot context, TestFailureDetail failure) {
-        FixConversationSession session = fixGateway.startConversation(context, failure);
+        FixConversationSession session = fixGateway.startConversation(
+                context,
+                failure,
+                executionSettings.useMethodScopedPrompts());
         return applyLatestResponse(context, session, List.of(failure));
     }
 
     private FixApplicationResult applyGroupedFailureFix(TestContextSnapshot context, List<TestFailureDetail> failures) {
-        FixConversationSession session = fixGateway.startConversation(context, failures);
+        FixConversationSession session = fixGateway.startConversation(
+                context,
+                failures,
+                executionSettings.useMethodScopedPrompts());
         return applyLatestResponse(context, session, failures);
     }
 

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/config/FixIterationExecutionSettings.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/config/FixIterationExecutionSettings.java
@@ -10,14 +10,18 @@ public final class FixIterationExecutionSettings {
 
     private final boolean runCompilation;
     private final boolean runTestExecution;
+    private final boolean methodScopedPrompts;
 
-    public FixIterationExecutionSettings(boolean runCompilation, boolean runTestExecution) {
+    public FixIterationExecutionSettings(boolean runCompilation,
+                                         boolean runTestExecution,
+                                         boolean methodScopedPrompts) {
         this.runCompilation = runCompilation;
         this.runTestExecution = runTestExecution;
+        this.methodScopedPrompts = methodScopedPrompts;
     }
 
     public static FixIterationExecutionSettings defaults() {
-        return new FixIterationExecutionSettings(true, true);
+        return new FixIterationExecutionSettings(true, true, false);
     }
 
     public boolean runCompilation() {
@@ -26,6 +30,10 @@ public final class FixIterationExecutionSettings {
 
     public boolean runTestExecution() {
         return runTestExecution;
+    }
+
+    public boolean useMethodScopedPrompts() {
+        return methodScopedPrompts;
     }
 
     @Override
@@ -37,12 +45,13 @@ public final class FixIterationExecutionSettings {
             return false;
         }
         return runCompilation == settings.runCompilation
-                && runTestExecution == settings.runTestExecution;
+                && runTestExecution == settings.runTestExecution
+                && methodScopedPrompts == settings.methodScopedPrompts;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(runCompilation, runTestExecution);
+        return Objects.hash(runCompilation, runTestExecution, methodScopedPrompts);
     }
 
     @Override
@@ -50,6 +59,7 @@ public final class FixIterationExecutionSettings {
         return "FixIterationExecutionSettings{"
                 + "runCompilation=" + runCompilation
                 + ", runTestExecution=" + runTestExecution
+                + ", methodScopedPrompts=" + methodScopedPrompts
                 + '}';
     }
 }

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixGateway.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixGateway.java
@@ -19,12 +19,26 @@ public final class GigachatFixGateway {
         this.builder = Objects.requireNonNull(builder, "builder");
     }
 
-    public FixConversationSession startConversation(TestContextSnapshot context, TestFailureDetail failure) {
-        return startConversation(context, List.of(failure));
+    public FixConversationSession startConversation(TestContextSnapshot context,
+                                                    TestFailureDetail failure) {
+        return startConversation(context, failure, false);
     }
 
-    public FixConversationSession startConversation(TestContextSnapshot context, List<TestFailureDetail> failures) {
-        String prompt = builder.buildFixPrompt(context, failures);
+    public FixConversationSession startConversation(TestContextSnapshot context,
+                                                    TestFailureDetail failure,
+                                                    boolean methodScopedPrompt) {
+        return startConversation(context, List.of(failure), methodScopedPrompt);
+    }
+
+    public FixConversationSession startConversation(TestContextSnapshot context,
+                                                    List<TestFailureDetail> failures) {
+        return startConversation(context, failures, false);
+    }
+
+    public FixConversationSession startConversation(TestContextSnapshot context,
+                                                    List<TestFailureDetail> failures,
+                                                    boolean methodScopedPrompt) {
+        String prompt = builder.buildFixPrompt(context, failures, methodScopedPrompt);
         FixConversationSession session = new FixConversationSession(prompt);
         String response = client.sendPrompt(prompt, Map.of());
         session.recordModelResponse(response);

--- a/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilder.java
+++ b/test-orchestration/src/main/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilder.java
@@ -13,10 +13,17 @@ public final class GigachatFixRequestBuilder {
 
     public String buildFixPrompt(TestContextSnapshot context, TestFailureDetail failure) {
         Objects.requireNonNull(failure, "failure");
-        return buildFixPrompt(context, List.of(failure));
+        return buildFixPrompt(context, List.of(failure), false);
     }
 
-    public String buildFixPrompt(TestContextSnapshot context, List<TestFailureDetail> failures) {
+    public String buildFixPrompt(TestContextSnapshot context,
+                                 List<TestFailureDetail> failures) {
+        return buildFixPrompt(context, failures, false);
+    }
+
+    public String buildFixPrompt(TestContextSnapshot context,
+                                 List<TestFailureDetail> failures,
+                                 boolean methodScopedPrompt) {
         Objects.requireNonNull(context, "context");
         Objects.requireNonNull(failures, "failures");
         if (failures.isEmpty()) {
@@ -32,6 +39,10 @@ public final class GigachatFixRequestBuilder {
             appendMultipleFailureDescription(prompt, failures);
         }
 
+        if (methodScopedPrompt) {
+            prompt.append("Only update the listed failing test methods. Do not rewrite unrelated tests unless a change is strictly required for compilation.\n");
+        }
+
         prompt.append("Here is the current content of the test class. Keep the class public and avoid inventing additional domain types or placeholder enums.\n");
         prompt.append("```java\n").append(context.getSourceCode()).append("\n```\n\n");
 
@@ -41,7 +52,7 @@ public final class GigachatFixRequestBuilder {
             prompt.append('\n');
         }
 
-        if (!context.getEnumConstants().isEmpty()) {
+        if (!context.getEnumConstants().isEmpty() && !methodScopedPrompt) {
             prompt.append("Available enum constants:\n");
             context.getEnumConstants().forEach((enumName, constants) -> {
                 prompt.append("- ").append(enumName).append('\n');
@@ -50,7 +61,7 @@ public final class GigachatFixRequestBuilder {
             });
         }
 
-        if (!context.getDependencyMethods().isEmpty()) {
+        if (!context.getDependencyMethods().isEmpty() && !methodScopedPrompt) {
             prompt.append("Documented dependency methods:\n");
             context.getDependencyMethods().forEach((type, members) -> {
                 prompt.append("- ").append(type).append('\n');
@@ -59,13 +70,18 @@ public final class GigachatFixRequestBuilder {
             });
         }
 
-        if (!context.getSupportingTypes().isEmpty()) {
+        if (!context.getSupportingTypes().isEmpty() && !methodScopedPrompt) {
             prompt.append("Supporting types:\n");
             context.getSupportingTypes().forEach((type, members) -> {
                 prompt.append("- ").append(type).append('\n');
                 members.forEach(member -> prompt.append("  - ").append(member).append('\n'));
                 prompt.append('\n');
             });
+        }
+
+        if (methodScopedPrompt
+                && (!context.getDependencyMethods().isEmpty() || !context.getSupportingTypes().isEmpty())) {
+            prompt.append("(Dependency documentation omitted for brevity. Reuse existing imports or request specific APIs if needed.)\n\n");
         }
 
         prompt.append("Please update only the shown test class so that it satisfies the documented APIs and addresses every failure described above.\n");

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/TestFixIterationCoordinatorTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/TestFixIterationCoordinatorTest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestFixIterationCoordinatorTest {
 
@@ -146,7 +148,7 @@ class TestFixIterationCoordinatorTest {
                 new TestFixApplier(),
                 new GigachatResponseParser(),
                 loopHandler,
-                new FixIterationExecutionSettings(false, true),
+                new FixIterationExecutionSettings(false, true, false),
                 signatureVerifier);
 
         Path tempSource = Files.createTempFile("OrderTest", ".java");
@@ -190,7 +192,7 @@ class TestFixIterationCoordinatorTest {
                 new TestFixApplier(),
                 new GigachatResponseParser(),
                 loopHandler,
-                new FixIterationExecutionSettings(true, false),
+                new FixIterationExecutionSettings(true, false, false),
                 signatureVerifier);
 
         Path tempSource = Files.createTempFile("OrderTest", ".java");
@@ -216,6 +218,50 @@ class TestFixIterationCoordinatorTest {
 
         TestContextSnapshot snapshot = contexts.get("com.acme.discount.OrderTest");
         assertEquals("public class OrderTest {}", snapshot.getSourceCode());
+    }
+
+    @Test
+    void enablesMethodScopedPromptsWhenRequested() throws Exception {
+        RecordingPromptClient promptClient = new RecordingPromptClient();
+        GigachatFixGateway gateway = new GigachatFixGateway(promptClient, new GigachatFixRequestBuilder());
+
+        ScriptedRunner runner = new ScriptedRunner();
+        runner.addResult(new TestRunResult(1, false, Duration.ZERO, failingOutput()));
+        runner.addResult(new TestRunResult(0, false, Duration.ZERO, "BUILD SUCCESSFUL"));
+        runner.addResult(new TestRunResult(0, false, Duration.ZERO, "All tests passed"));
+
+        CapturingLoopHandler loopHandler = new CapturingLoopHandler();
+        RecordingSignatureVerifier signatureVerifier = new RecordingSignatureVerifier();
+
+        TestFixIterationCoordinator coordinator = new TestFixIterationCoordinator(
+                runner,
+                new TestFailureCollector(),
+                gateway,
+                new TestFixApplier(),
+                new GigachatResponseParser(),
+                loopHandler,
+                new FixIterationExecutionSettings(true, true, true),
+                signatureVerifier);
+
+        Path tempSource = Files.createTempFile("OrderTest", ".java");
+        tempSource.toFile().deleteOnExit();
+        Map<String, TestContextSnapshot> contexts = new HashMap<>();
+        contexts.put("com.acme.discount.OrderTest", new TestContextSnapshot(
+                "com.acme.discount.OrderTest",
+                tempSource,
+                "public class OrderTest {}",
+                Map.of("com.acme.discount.Order", List.of("Order(String id)")),
+                Map.of("com.acme.discount.CustomerProfile", List.of("CustomerProfile(String id)")),
+                Map.of(),
+                List.of("void Order.place()")));
+
+        coordinator.executeAndAttemptFix(
+                TestRunRequest.builder(Path.of(".")).build(),
+                contexts);
+
+        String prompt = promptClient.prompts.get(0).rawPrompt;
+        assertFalse(prompt.contains("Documented dependency methods"));
+        assertTrue(prompt.contains("Dependency documentation omitted for brevity"));
     }
 
     @Test
@@ -300,9 +346,11 @@ class TestFixIterationCoordinatorTest {
     }
 
     private static final class RecordedPrompt {
+        private final String rawPrompt;
         private final String includedSource;
 
         private RecordedPrompt(String prompt) {
+            this.rawPrompt = prompt;
             int start = prompt.indexOf("```java\n");
             if (start >= 0) {
                 int end = prompt.indexOf("```", start + 1);

--- a/test-orchestration/src/test/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilderTest.java
+++ b/test-orchestration/src/test/java/com/example/tests/orchestration/gigachat/GigachatFixRequestBuilderTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GigachatFixRequestBuilderTest {
@@ -75,5 +76,34 @@ class GigachatFixRequestBuilderTest {
 
         assertTrue(prompt.contains("1) `OrderTest.shouldCalculateSubtotal()`"));
         assertTrue(prompt.contains("2) `OrderTest.shouldApplyDiscount()`"));
+    }
+
+    @Test
+    void suppressesHeavySectionsWhenMethodScopedPromptRequested() {
+        TestContextSnapshot context = new TestContextSnapshot(
+                "com.acme.discount.OrderTest",
+                Paths.get("src/test/java/com/acme/discount/OrderTest.java"),
+                "public class OrderTest {}",
+                Map.of("com.acme.discount.Order", List.of(
+                        "Order(String orderId, LocalDate orderDate, List<OrderLine> lines)")),
+                Map.of("com.acme.discount.CustomerProfile", List.of(
+                        "CustomerProfile(String customerId, LoyaltyTier loyaltyTier, int loyaltyPoints, LocalDate memberSince, Map<ProductCategory, Double> averageMonthlySpend)")),
+                Map.of(),
+                List.of("DiscountResult Order.calculate(CustomerProfile profile)"));
+
+        TestFailureDetail failure = new TestFailureDetail(
+                "OrderTest",
+                "shouldCalculateSubtotal()",
+                "Assertion failed",
+                List.of("Expected :30.0", "Actual   :90.0"));
+
+        GigachatFixRequestBuilder builder = new GigachatFixRequestBuilder();
+        String prompt = builder.buildFixPrompt(context, List.of(failure), true);
+
+        assertTrue(prompt.contains("Only update the listed failing test methods"));
+        assertTrue(prompt.contains("API reference reminders"));
+        assertTrue(prompt.contains("Dependency documentation omitted for brevity"));
+        assertFalse(prompt.contains("Documented dependency methods"));
+        assertFalse(prompt.contains("Supporting types:"));
     }
 }


### PR DESCRIPTION
## Summary
- enable method-scoped fix prompts whenever diff-method generation runs alongside compilation or execution retries
- add configuration plumbing and gateway overloads to pass the method-scoped flag through the orchestration pipeline
- trim large dependency sections from fix prompts in method-scoped mode and cover the behavior with unit tests

## Testing
- `./gradlew test` *(fails: gradle wrapper jar is unavailable in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_690518ff7cdc8320b087cc12fff16419